### PR TITLE
Add trigger events for push to master in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Make PDF using pandoc
 
+on:
+  push:
+    branches:
+      - master
+
 jobs:
   make_pdf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -1,5 +1,10 @@
 name: Make PDF using pandoc
 
+on:
+  push:
+    branches:
+      - master
+
 jobs:
   pandoc_pdf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI currently dies with this error on `ci.yml` and `pandoc.yml`:

```
Error: .github#L1
No event triggers defined in `on`
```

This should fix it.