### PR TITLE
Fix CI make_pdf missing texlive-latex-extra package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          sudo apt install pandoc texlive
+          sudo apt install pandoc texlive texlive-latex-extra
           make pdf
           make epub
       - uses: actions/upload-artifact@master


### PR DESCRIPTION
The `letltxmacro` LaTeX package comes from `texlive-latex-extra`, so the CI needs it to work.