### PR TITLE
Change arg type in function declaration

### DIFF
--- a/src/plugins/dev-asm.md
+++ b/src/plugins/dev-asm.md
@@ -61,7 +61,7 @@ uninstall:
 #include <r_lib.h>
 #include <r_asm.h>
 
-static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
+static int disassemble(RAsm *a, RAnalOp *op, const ut8 *buf, int len) {
 	struct op_cmd cmd = {
 		.instr = "",
 		.operands = ""


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

According to the release notes for `5.8.0`, one change that was incorporated was:

> Kill RAsmOp, we can reuse RAnalOp in here

Accordingly, this PR changes `RAsmOp` to `RAnalOp` in the `disassemble` function prototype.