### PR TITLE
replace old dead link with new correct one

### DIFF
--- a/src/disassembling/adding_metadata.md
+++ b/src/disassembling/adding_metadata.md
@@ -3,7 +3,7 @@
 The typical work involved in reversing binary files makes powerful annotation capabilities essential.
 Radare offers multiple ways to store and retrieve such metadata.
 
-By following common basic UNIX principles, it is easy to write a small utility in a scripting language which uses `objdump`, `otool` or any other existing utility to obtain information from a binary and to import it into radare. For example, take a look at `idc2r.py` shipped with [radare2ida](https://github.com/radareorg/radare2ida). To use it, invoke it as `idc2r.py file.idc > file.r2`. It reads an IDC file exported from an IDA Pro database and produces an r2 script containing the same comments, names of functions and other data. You can import the resulting 'file.r2' by using the dot `.` command of radare:
+By following common basic UNIX principles, it is easy to write a small utility in a scripting language which uses `objdump`, `otool` or any other existing utility to obtain information from a binary and to import it into radare. For example, take a look at `idc2r.py` shipped with [radare2ida](https://github.com/radareorg/radare2-extras/tree/master/r2ida). To use it, invoke it as `idc2r.py file.idc > file.r2`. It reads an IDC file exported from an IDA Pro database and produces an r2 script containing the same comments, names of functions and other data. You can import the resulting 'file.r2' by using the dot `.` command of radare:
 ```
 [0x00000000]> . file.r2
 ```


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: no issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [X] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
The radar2 book links to the old location of `radare2ida` which does not exist anymore.
Instead, make it should point to the new `radare2-extras/r2ida` location.