### PR TITLE
configurating_the_search.md: Fixed spelling mistakes and added examples

### DIFF
--- a/src/search_bytes/configurating_the_search.md
+++ b/src/search_bytes/configurating_the_search.md
@@ -4,7 +4,7 @@ The radare2 search engine can be configured through several configuration variab
 ```
 e cmd.hit = x         ; radare2 command to execute on every search hit
 e search.distance = 0 ; search string distance
-e search.in = [foo]   ; pecify search boundarie. Supported values are listed under e search.in=??
+e search.in = [foo]   ; specify search boundaries. Supported values are listed under e search.in=??
 e search.align = 4    ; only show search results aligned by specified boundary.
 e search.from = 0     ; start address
 e search.to = 0       ; end address

--- a/src/search_bytes/configurating_the_search.md
+++ b/src/search_bytes/configurating_the_search.md
@@ -14,3 +14,5 @@ e search.flags = true ; if enabled, create flags on hits
 The `search.align` variable is used to limit valid search hits to certain alignment. For example, with `e search.align=4` you will see only hits found at 4-bytes aligned offsets.
 
 The `search.flags` boolean variable instructs the search engine to flag hits so that they can be referenced later. If a currently running search is interrupted with `Ctrl-C` keyboard sequence, current search position is flagged with `search_stop`.
+
+The `search.in` variable specifies search boundaries. To search entire memory, use `e search.in = dbg.maps`. The default value is `dbg.map`.


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [x] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
1. Fixed small spelling errors.
2. Added helpful example to `e search.in` option.