### PR TITLE
Symbol servers need to be space separated now

### DIFF
--- a/src/analysis/symbols.md
+++ b/src/analysis/symbols.md
@@ -24,9 +24,9 @@ pdb.useragent = Microsoft-Symbol-Server/6.11.0001.402
 
 Using the variable `pdb.server` you can change the address where radare2 will try to
 download the PDB file by the GUID stored in the executable header.
-You can make use of multiple symbol servers by separating each URL with a semi-colon:
+You can make use of multiple symbol servers by separating each URL with a space:
 ```
-e pdb.server = https://msdl.microsoft.com/download/symbols;https://symbols.mozilla.org/
+e pdb.server = https://msdl.microsoft.com/download/symbols https://symbols.mozilla.org
 ```
 On Windows,  you can also use local network share paths (UNC paths) as symbol servers.
 


### PR DESCRIPTION
Symbol servers need to be space separated now

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
