### PR TITLE
Fix pandoc images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get --assume-yes update
-          sudo apt-get --assume-yes install pandoc texlive texlive-latex-extra
+          sudo apt-get --assume-yes install pandoc texlive-xetex
       - name: Build ebooks
         run: make
       - name: Pub

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: pdf epub
 
+.PHONY: epub pdf pdf_old gmi
+
 pdf_old: node_modules
 	npm run build
 	npm run pdf
@@ -10,36 +12,19 @@ node_modules:
 
 # CHAPTERS=$(shell find src -iname *.md)
 CHAPTERS=$(shell grep -Eoi '\([^\)]+' src/SUMMARY.md | sed -e 's,^.,src/,')
-PANDOC_PDF_OPTIONS+=-V papersize:a3
-PANDOC_PDF_OPTIONS+=-V geometry:margin=1.5cm
-PANDOC_PDF_OPTIONS+=--pdf-engine=xelatex
-PANDOC_PDF_OPTIONS+=--resource-path=img
-PANDOC_PDF_OPTIONS+=--toc-depth=5 --toc
+PANDOC_OPTIONS+=-f markdown+rebase_relative_paths
+PANDOC_OPTIONS+=--toc-depth=5 --toc
+PANDOC_OPTIONS+=-V papersize:a3
+PANDOC_OPTIONS+=-V geometry:margin=1.5cm
 PANDOC_PDF_OPTIONS+=-B src/COVER.md
-# PANDOC_OPTIONS+=--template md.template
-PANDOC_EPUB_OPTIONS+=-V papersize:a3
-PANDOC_EPUB_OPTIONS+=-V geometry:margin=1.5cm
-PANDOC_EPUB_OPTIONS+=--resource-path=img
-PANDOC_EPUB_OPTIONS+=--toc-depth=5 --toc
+PANDOC_PDF_OPTIONS+=--pdf-engine=xelatex
 PANDOC_EPUB_OPTIONS+=--epub-cover-image=cover.jpg
 
 pdf:
-	# Cant add images because of this bug: https://github.com/jgm/pandoc/issues/3752
-	# pandoc src/**/*.md --verbose --pdf-engine=xelatex -o r2book.pdf
-	# pandoc  src/**/*.md --pdf-engine=xelatex -o r2book.pdf
-	rm -rf img ; mkdir -p img ; for a in $(shell find src | grep png$$) ; do cp $$a img ; done
-	cp cover.jpg img
-	pandoc $(CHAPTERS) $(PANDOC_OPTIONS) -o r2book.pdf
-	rm -rf img
+	pandoc $(CHAPTERS) $(PANDOC_OPTIONS) $(PANDOC_PDF_OPTIONS) -o r2book.pdf
 
 epub:
-	# Cant add images because of this bug: https://github.com/jgm/pandoc/issues/3752
-	# pandoc src/**/*.md --verbose --pdf-engine=xelatex -o r2book.pdf
-	# pandoc  src/**/*.md --pdf-engine=xelatex -o r2book.pdf
-	rm -rf img ; mkdir -p img ; for a in $(shell find src | grep png$$) ; do cp $$a img ; done
-	cp cover.jpg img
-	pandoc $(CHAPTERS) $(PANDOC_EPUB_OPTIONS) -o r2book.epub
-	rm -rf img
+	pandoc $(CHAPTERS) $(PANDOC_OPTIONS) $(PANDOC_EPUB_OPTIONS) -o r2book.epub
 
 MD2GMI=md2gmi/md2gmi
 
@@ -55,5 +40,3 @@ gmi: $(MD2GMI)
 	for a in $(shell find src -type d) ; do b=`echo $$a |sed -e 's,src/,gmi/,'`; mkdir -p $$b ; done
 	for a in $(shell find src | grep md$$) ; do b=`echo $$a |sed -e 's,src/,gmi/,' -e 's,md$$,gmi,'` ; $(MD2GMI) -o $$b < $$a; done
 	cp -f gmi/intro.gmi gmi/index.gmi
-
-.PHONY: gmi

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,17 @@ node_modules:
 
 # CHAPTERS=$(shell find src -iname *.md)
 CHAPTERS=$(shell grep -Eoi '\([^\)]+' src/SUMMARY.md | sed -e 's,^.,src/,')
+
 PANDOC_OPTIONS+=-f markdown+rebase_relative_paths
 PANDOC_OPTIONS+=--metadata-file=metadata.yaml
 PANDOC_OPTIONS+=--toc-depth=5 --toc
 PANDOC_OPTIONS+=-V papersize:a3
 PANDOC_OPTIONS+=-V geometry:margin=1.5cm
-PANDOC_PDF_OPTIONS+=-B src/COVER.md
+
+# PDF: Add cover and hide title text page
+PANDOC_PDF_OPTIONS+=-B cover.tex -V title:
 PANDOC_PDF_OPTIONS+=--pdf-engine=xelatex
+
 PANDOC_EPUB_OPTIONS+=--epub-cover-image=cover.jpg
 
 pdf:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ node_modules:
 # CHAPTERS=$(shell find src -iname *.md)
 CHAPTERS=$(shell grep -Eoi '\([^\)]+' src/SUMMARY.md | sed -e 's,^.,src/,')
 PANDOC_OPTIONS+=-f markdown+rebase_relative_paths
+PANDOC_OPTIONS+=--metadata-file=metadata.yaml
 PANDOC_OPTIONS+=--toc-depth=5 --toc
 PANDOC_OPTIONS+=-V papersize:a3
 PANDOC_OPTIONS+=-V geometry:margin=1.5cm

--- a/book.toml
+++ b/book.toml
@@ -2,6 +2,7 @@
 title = "The Official Radare2 Book"
 author = "pancake <pancake@nopcode.org>"
 description = "The Official Radare2 Book"
+language = "en"
 
 [build]
 create-missing = false

--- a/cover.tex
+++ b/cover.tex
@@ -1,0 +1,3 @@
+\includegraphics{cover.jpg}
+\thispagestyle{empty}
+\cleardoublepage

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,10 @@
+title: The Official Radare2 Book
+lang: en-US
+author:
+  - pancake <pancake@nopcode.org>
+keywords:
+  - book
+  - reverse-engineering
+  - radare2
+  - reversing
+  - radare

--- a/src/COVER.md
+++ b/src/COVER.md
@@ -1,3 +1,3 @@
 cover
-![cover](cover.jpg)
+![cover](../cover.jpg)
 cover2


### PR DESCRIPTION
1. Fix error loading images using pandoc and remove the workaround from the `Makefile`.
2. Add PDF and ePub metadata in `metadata.yaml` file.
3. Fix PDF cover