### PR TITLE
Add build gmi to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
         run: |
           sudo apt-get --assume-yes update
           sudo apt-get --assume-yes install pandoc texlive-xetex texinfo
+          go install github.com/n0x1m/md2gmi@latest
       - name: Build ebooks
-        run: make pdf epub info
-      - name: Pub
+        run: make pdf epub info gmi
+      - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: r2book
@@ -25,6 +26,7 @@ jobs:
             r2book.pdf
             r2book.epub
             r2book.info.gz
+            r2book-gmi.tar.gz
 
   # Release creation
   check_release:
@@ -77,3 +79,4 @@ jobs:
             r2book.pdf
             r2book.epub
             r2book.info.gz
+            r2book-gmi.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ _book/*
 *.rej
 *.bak
 *.log
+gmi/
 r2book.pdf
 r2book.epub
 r2book.texi
 r2book.info*
+r2book-gmi.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -40,17 +40,15 @@ info: texi
 	makeinfo --force --no-split r2book.texi
 	gzip -9n r2book.info
 
-MD2GMI=md2gmi/md2gmi
+GOPATH?=$(HOME)/go
+GOBIN?=$(GOPATH)/bin
+MD2GMI?=$(GOBIN)/md2gmi
 
-md2gmi:
-	git clone https://github.com/n0x1m/md2gmi
-
-$(MD2GMI): md2gmi
-	cd md2gmi && go build .
-
-gmi: $(MD2GMI)
+gmi:
+	@test -x $(MD2GMI) || (echo "ERROR: Missing md2gmi.\nTo install run: go install github.com/n0x1m/md2gmi@latest"; false)
 	rm -rf gmi
 	mkdir -p gmi
 	for a in $(shell find src -type d) ; do b=`echo $$a |sed -e 's,src/,gmi/,'`; mkdir -p $$b ; done
-	for a in $(shell find src | grep md$$) ; do b=`echo $$a |sed -e 's,src/,gmi/,' -e 's,md$$,gmi,'` ; $(MD2GMI) -o $$b < $$a; done
-	cp -f gmi/intro.gmi gmi/index.gmi
+	for a in $(shell find src -type f -name \*.md) ; do b=`echo $$a |sed -e 's,src/,gmi/,' -e 's,md$$,gmi,'` ; $(MD2GMI) -i $$a -o $$b; done
+	ln -v gmi/SUMMARY.gmi gmi/index.gmi
+	tar -czf r2book-gmi.tar.gz -C gmi .


### PR DESCRIPTION
Changed Makefile use md2gmi user install (instead of folder build).
With an error message if it is not installed:
```
ERROR: Missing md2gmi.
To install run: go install github.com/n0x1m/md2gmi@latest
```

Also added to the CI to build it and upload to each release.