### PR TITLE
Set some fenced code languages

### DIFF
--- a/src/analysis/calling_conventions.md
+++ b/src/analysis/calling_conventions.md
@@ -3,7 +3,7 @@
 Radare2 uses calling conventions to help in identifying function formal arguments and return types.
 It is used also as a guide for basic function prototype and type propagation.
 
-```
+```console
 [0x00000000]> afc?
 |Usage: afc[agl?]
 | afc convention  Manually set calling convention for current function
@@ -21,7 +21,7 @@ It is used also as a guide for basic function prototype and type propagation.
 
 * To list all available calling conventions for current architecture using `afcl` command
 
-```
+```console
 [0x00000000]> afcl
 amd64
 ms
@@ -29,7 +29,7 @@ ms
 
 * To display function prototype of standard library functions you have `afcf` command
 
-```
+```console
 [0x00000000]> afcf printf
 int printf(const char *format)
 [0x00000000]> afcf fgets
@@ -38,7 +38,7 @@ char *fgets(char *s, int size, FILE *stream)
 
 All this information is loaded via sdb under `/libr/anal/d/cc-[arch]-[bits].sdb`
 
-```
+```c
 default.cc=amd64
 
 ms=cc

--- a/src/analysis/code_analysis.md
+++ b/src/analysis/code_analysis.md
@@ -12,7 +12,7 @@ The most common radare2 analysis command sequence is `aa`, which stands for "ana
 
 Take some time to understand what each command does and the results after running them to find the best one for your needs.
 
-```
+```console
 [0x08048440]> aa
 [0x08048440]> pdf @ main
 		   ; DATA XREF from 0x08048457 (entry0)
@@ -82,7 +82,7 @@ One of the most important "basic" analysis commands is the set of `af` subcomman
 "analyze function". Using this command you can either allow automatic analysis of the particular
 function or perform completely manual one.
 
-```
+```console
 [0x00000000]> af?
 Usage: af
 | af ([name]) ([addr])                  analyze functions (start at addr or $$)
@@ -132,7 +132,7 @@ the one specified by name as an argument, `aff` to readjust the function after a
 Apart from those semi-automatic ways to edit/analyze the function, you can hand craft it in the manual mode with `af+` command and edit basic blocks of it using `afb` commands.
 Before changing the basic blocks of the function it is recommended to check the already presented ones:
 
-```
+```console
 [0x00003ac0]> afb
 0x00003ac0 0x00003b7f 01:001A 191 f 0x00003b7f
 0x00003b7f 0x00003b84 00:0000 5 j 0x00003b92 f 0x00003b84
@@ -146,7 +146,7 @@ Before changing the basic blocks of the function it is recommended to check the 
 
 Before we start, let's prepare a binary file first. Write in `example.c`:
 
-```C
+```c
 int code_block()
 {
   int result = 0;
@@ -162,7 +162,7 @@ then compile with `gcc -c example.c -m32 -O0 -fno-pie`, and open the object file
 
 Since we haven't analyzed it yet, the `pdf` command will not print out the disassembly here:
 
-```
+```console
 $ r2 example.o 
 [0x08000034]> pdf
 p: Cannot find function at 0x08000034
@@ -193,14 +193,14 @@ our goal is to handcraft a function with the following structure
 
 create a function at 0x8000034 named code_block:
 
-```
+```console
 [0x8000034]> af+ 0x8000034 code_block
 ```
 
 In most cases, we use jump or call instructions as code block boundaries. so the range of first block is from `0x08000034 push ebp` to `0x08000048 jmp 0x8000052`.
 use `afb+` command to add it.
 
-```
+```console
 [0x08000034]> afb+ code_block 0x8000034 0x800004a-0x8000034 0x8000052
 ```
 
@@ -208,20 +208,20 @@ note that the basic syntax of `afb+` is `afb+ function_address block_address blo
 
 the next block (0x08000052 ~ 0x08000056) is more likeyly an if conditional statement which has two branches. It will jump to 0x800004a if `jle-less or equal`, otherwise (the fail condition) jump to next instruction -- 0x08000058.:
 
-```
+```console
 [0x08000034]> afb+ code_block 0x8000052 0x8000058-0x8000052 0x800004a 0x8000058
 ```
 
 follow the control flow and create the remaining two blocks (two branches) :
 
-```
+```console
 [0x08000034]> afb+ code_block 0x800004a 0x8000052-0x800004a 0x8000052
 [0x08000034]> afb+ code_block 0x8000058 0x800005d-0x8000058
 ```
 
 check our work:
 
-```
+```console
 [0x08000034]> afb
 0x08000034 0x0800004a 00:0000 22 j 0x08000052
 0x0800004a 0x08000052 00:0000 8 j 0x08000052
@@ -279,7 +279,7 @@ The most commonly used `ax` commands are `axt` and `axf`, especially as a part o
 scripts. Lets say we see the string in the data or a code section and want to find all places
 it was referenced from, we should use `axt`:
 
-```
+```console
 [0x0001783a]> pd 2
 ;-- str.02x:
 ; STRING XREF from 0x00005de0 (sub.strlen_d50)
@@ -299,7 +299,7 @@ sub.strlen_d50 0x5de0 [STRING] lea rcx, str.02x
 
 There are also some useful commands under `axt`. Use `axtg` to generate radare2 commands which will help you to create graphs according to the XREFs.
 
-```
+```console
 [0x08048320]> s main
 [0x080483e0]> axtg
 agn 0x8048337 "entry0 + 23"
@@ -311,7 +311,7 @@ Use `axt*` to split the radare2 commands and set flags on those corresponding XR
 
 Also under `ax` is `axg`, which finds the path between two points in the file by showing an XREFs graph to reach the location or function. For example:
 
-```
+```console
 :> axg sym.imp.printf
 - 0x08048a5c fcn 0x08048a5c sym.imp.printf
   - 0x080483e5 fcn 0x080483e0 main
@@ -476,7 +476,7 @@ Usage: ah[lba-]  Analysis Hints
 
 One of the most common cases is to set a particular numeric base for immediates:
 
-```
+```console
 [0x00003d54]> ahi?
 Usage: ahi [2|8|10|10u|16|bodhipSs] [@ offset]   Define numeric base
 | ahi <base>  set numeric base (2, 8, 10, 16)
@@ -506,7 +506,7 @@ Usage: ahi [2|8|10|10u|16|bodhipSs] [@ offset]   Define numeric base
 It is notable that some analysis stages or commands add the internal analysis hints,
 which can be checked with `ah` command:
 
-```
+```console
 [0x00003d54]> ah
  0x00003d54 - 0x00003d54 => immbase=2
 [0x00003d54]> ah*
@@ -518,7 +518,7 @@ relocation, which is unknown for radare2, thus we can change the value manually.
 The current analysis information about a particular opcode can be checked with `ao` command.
 We can use `ahc` command for performing such a change:
 
-```
+```console
 [0x00003cee]> pd 2
 0x00003cee      e83d080100     call sub.__errno_location_530
 0x00003cf3      85c0           test eax, eax
@@ -574,7 +574,7 @@ As you can see, despite the unchanged disassembly view the jump address in opcod
 If anything of the previously described didn't help, you can simply override shown disassembly with anything you
 like:
 
-```
+```console
 [0x00003d54]> pd 2
 0x00003d54      0583000000     add eax, 10000011b
 0x00003d59      3d13010000     cmp eax, 0x113

--- a/src/analysis/graphs.md
+++ b/src/analysis/graphs.md
@@ -25,7 +25,7 @@ Let's dive into the world of radare2 graphs and unlock new dimensions in your an
 
 Radare2 supports various types of graph available through commands starting with `ag`:
 
-```
+```console
 [0x00005000]> ag?
 Usage: ag<graphtype><format> [addr]
 Graph commands:
@@ -127,7 +127,7 @@ To easily execute the printed commands, it is possible to prepend a dot to the c
 
 This is a sample r2 script to create a graph using commands:
 
-```
+```console
 [0x00000000]> e scr.utf8=0
 [0x00000000]> agn foo
 [0x00000000]> agn bar

--- a/src/analysis/syscalls.md
+++ b/src/analysis/syscalls.md
@@ -4,7 +4,7 @@ Radare2 allows manual search for assembly code looking like a syscall operation.
 For example on ARM platform usually they are represented by the `svc` instruction,
 on the others can be a different instructions, e.g. `syscall` on x86 PC.
 
-```
+```console
 [0x0001ece0]> /ad/ svc
 ...
 0x000187c2   # 2: svc 0x76
@@ -18,7 +18,7 @@ to setup those configuration options accordingly. You can use `asl` command
 to check if syscalls' support is set up properly and as you expect.
 The command lists syscalls supported for your platform.
 
-```
+```console
 [0x0001ece0]> asl
 ...
 sd_softdevice_enable = 0x80.16
@@ -30,7 +30,7 @@ sd_softdevice_is_enabled = 0x80.18
 If you setup ESIL stack with `aei` or `aeim`, you can use `/as` command to search
 the addresses where particular syscalls were found and list them.
 
-```
+```console
 [0x0001ece0]> aei
 [0x0001ece0]> /as
 0x000187c2 sd_ble_gap_disconnect
@@ -43,7 +43,7 @@ To reduce searching time it is possible to [restrict the searching](../search/co
 
 Using the [ESIL emulation](../emulation/intro.md) radare2 can print syscall arguments in the disassembly output. To enable the linear (but very rough) emulation use `asm.emu` configuration variable:
 
-```
+```console
 [0x0001ece0]> e asm.emu=true
 [0x0001ece0]> s 0x000187c2
 [0x000187c2]> pdf~svc
@@ -53,7 +53,7 @@ Using the [ESIL emulation](../emulation/intro.md) radare2 can print syscall argu
 
 In case of executing `aae` (or `aaaa` which calls `aae`) command radare2 will push found syscalls to a special `syscall.` flagspace, which can be useful for automation purpose:
 
-```
+```console
 [0x000187c2]> fs
 0    0 * imports
 1    0 * symbols
@@ -70,7 +70,7 @@ In case of executing `aae` (or `aaaa` which calls `aae`) command radare2 will pu
 
 It also can be interactively navigated through within HUD mode (`V_`)
 
-```
+```console
 0> syscall.sd_ble_gap_disconnect
  - 0x000187b2  syscall.sd_ble_gap_disconnect
    0x000187c2  syscall.sd_ble_gap_disconnect.0
@@ -81,7 +81,7 @@ It also can be interactively navigated through within HUD mode (`V_`)
 
 When debugging in radare2, you can use `dcs` to continue execution until the next syscall. You can also run `dcs*` to trace all syscalls.
 
-```
+```console
 [0xf7fb9120]> dcs*
 Running child until syscalls:-1 
 child stopped with signal 133
@@ -95,7 +95,7 @@ child stopped with signal 133
 
 radare2 also has a syscall name to syscall number utility. You can return the syscall name of a given syscall number or vice versa, without leaving the shell.
 
-```
+```console
 [0x08048436]> asl 1
 exit
 [0x08048436]> asl write

--- a/src/analysis/types.md
+++ b/src/analysis/types.md
@@ -6,7 +6,7 @@ the internal SDB, thus are introspectable with `k` command.
 
 Most of the related commands are located in `t` namespace:
 
-```
+```console
 [0x00000000]> t?
 | Usage: t   # cparse types commands
 | t                          List all loaded types
@@ -45,7 +45,7 @@ depending on the binary or debuggee platform/compiler.
 Basic types can be listed using `t` command. For the structured types
 you need to use `ts`, for unions use `tu` and for enums — `te`.
 
-```
+```console
 [0x00000000]> t
 char
 char *
@@ -81,7 +81,7 @@ There are three easy ways to define a new type:
 * From the file using `to <filename>` command
 * Open  an `$EDITOR` to type the definitions in place using `to -`
 
-```
+```console
 [0x00000000]> "td struct foo {char* a; int b;}"
 [0x00000000]> cat ~/radare2-regressions/bins/headers/s3.h
 struct S1 {
@@ -97,7 +97,7 @@ S1
 
 Also note there is a config option to specify include directories for types parsing
 
-```
+```console
 [0x00000000]> e? dir.types
 dir.types: Default path to look for cparse type files
 [0x00000000]> e dir.types
@@ -112,7 +112,7 @@ into the sequence of `pf` commands. See more about [print format](../commandline
 
 The `tp` command uses the `pf` string to print all the members of type at the current offset/given address:
 
-```
+```console
 [0x00000000]> "td struct foo {char* a; int b;}"
 [0x00000000]> wx 68656c6c6f000c000000
 [0x00000000]> wz world @ 0x00000010 ; wx 17 @ 0x00000016
@@ -129,7 +129,7 @@ pf zd a b
 
 Also, you could fill your own data into the struct and print it using `tpx` command
 
-```
+```console
 [0x00000000]> tpx foo 414243440010000000
  a : 0x00000000 = "ABCD"
  b : 0x00000005 = 16
@@ -140,7 +140,7 @@ Also, you could fill your own data into the struct and print it using `tpx` comm
 The `tp` command just performs a temporary cast. But if we want to link some address or variable
 with the chosen type, we can use `tl` command to store the relationship in SDB.
 
-```
+```console
 [0x000051c0]> tl S1 = 0x51cf
 [0x000051c0]> tll
 (S1)
@@ -151,7 +151,7 @@ with the chosen type, we can use `tl` command to store the relationship in SDB.
 
 Moreover, the link will be shown in the disassembly output or visual mode:
 
-```
+```console
 [0x000051c0 15% 300 /bin/ls]> pd $r @ entry0
  ;-- entry0:
  0x000051c0      xor ebp, ebp
@@ -174,7 +174,7 @@ Moreover, the link will be shown in the disassembly output or visual mode:
 
 Once the struct is linked, radare2 tries to propagate structure offset in the function at current offset, to run this analysis on whole program or at any targeted functions after all structs are linked you have `aat` command:
 
-```
+```console
 [0x00000000]> aa?
 | aat [fcn]           Analyze all/given function to convert immediate to linked structure offsets (see tl?)
 ```
@@ -194,7 +194,7 @@ Note sometimes the emulation may not be accurate, for example as below :
 
 The return value of `malloc` may differ between two emulations, so you have to set the hint for return value manually using `ahr` command, so run `tl` or `aat` command after setting up the return value hint.
 
-```
+```console
 [0x000006da]> ah?
 | ahr val            set hint for return value of a function
 ```
@@ -205,7 +205,7 @@ There is one more important aspect of using types in radare2 - using `aht` you
 can change the immediate in the opcode to the structure offset.
 Lets see a simple example of [R]SI-relative addressing
 
-```
+```console
 [0x000052f0]> pd 1
 0x000052f0      mov rax, qword [rsi + 8]    ; [0x8:8]=0
 ```
@@ -213,8 +213,7 @@ Lets see a simple example of [R]SI-relative addressing
 Here `8` - is some offset in the memory, where `rsi` probably holds
 some structure pointer. Imagine that we have the following structures
 
-```
-
+```console
 [0x000052f0]> "td struct ms { char b[8]; int member1; int member2; };"
 [0x000052f0]> "td struct ms1 { uint64_t a; int member1; };"
 [0x000052f0]> "td struct ms2 { uint16_t a; int64_t b; int member1; };"
@@ -223,7 +222,7 @@ some structure pointer. Imagine that we have the following structures
 Now we need to set the proper structure member offset instead of `8` in this instruction.
 At first, we need to list available types matching this offset:
 
-```
+```console
 [0x000052f0]> ahts 8
 ms.member1
 ms1.member1
@@ -233,7 +232,7 @@ Note, that `ms2` is not listed, because it has no members with offset `8`.
 After listing available options we can link it to the chosen offset at
 the current address:
 
-```
+```console
 [0x000052f0]> aht ms1.member1
 [0x000052f0]> pd 1
 0x000052f0      488b4608       mov rax, qword [rsi + ms1.member1]    ; [0x8:8]=0
@@ -243,7 +242,7 @@ the current address:
 
 * Printing all fields in enum using `te` command
 
-```
+```console
 [0x00000000]> "td enum Foo {COW=1,BAR=2};"
 [0x00000000]> te Foo
 COW = 0x1
@@ -252,7 +251,7 @@ BAR = 0x2
 
 * Finding matching enum member for given bitfield and vice-versa
 
-```
+```console
 [0x00000000]> te Foo 0x1
 COW
 [0x00000000]> teb Foo COW
@@ -263,7 +262,7 @@ COW
 
 To see the internal representation of the types you can use `tk` command:
 
-```
+```console
 [0x000051c0]> tk~S1
 S1=struct
 struct.S1=x,y,z
@@ -362,7 +361,7 @@ defines the elements of `X` as comma separated values. After that, we just defin
 
 For example. we can have a struct like this one:
 
-```
+```c
 struct _FILETIME {
 	DWORD dwLowDateTime;
 	DWORD dwHighDateTime;
@@ -402,7 +401,7 @@ func.X.cc=calling_convention
 
 It should be self-explanatory. Let's do strncasecmp as an example for x86 arch for Linux machines. According to man pages, strncasecmp is defined as the following:
 
-```
+```c
 int strcasecmp(const char *s1, const char *s2, size_t n);
 ```
 

--- a/src/analysis/variables.md
+++ b/src/analysis/variables.md
@@ -56,7 +56,7 @@ As mentioned before the analysis loop relies heavily on types information while 
 variables analysis stages. Thus comes next very important command - `afvt`, which
 allows you to change the type of variable:
 
-```
+```console
 [0x00003b92]> afvs
 var int local_8h @ rsp+0x8
 var int local_10h @ rsp+0x10
@@ -87,7 +87,7 @@ variables being read and written. You can list those being read with `afvR` comm
 being written with `afvW` command. Both commands provide a list of the places those operations
 are performed:
 
-```
+```console
 [0x00003b92]> afvR
 local_48h  0x48ee
 local_30h  0x3c93,0x520b,0x52ea,0x532c,0x5400,0x3cfb
@@ -119,7 +119,7 @@ The type inference for local variables and arguments is well integrated with the
 
 Let's see an example of this with a simple [hello_world](https://github.com/radareorg/radare2book/tree/master/examples/hello_world) binary
 
-```
+```console
 [0x000007aa]> pdf
 |           ;-- main:
 / (fcn) sym.main 157
@@ -144,7 +144,7 @@ Let's see an example of this with a simple [hello_world](https://github.com/rada
 
 * After applying `afta`
 
-```
+```console
 [0x000007aa]> afta
 [0x000007aa]> pdf
 | ;-- main:

--- a/src/arch/8051.md
+++ b/src/arch/8051.md
@@ -22,7 +22,7 @@
 
 Set architecture to 8051:
 
-```sh
+```console
 $ r2 -a 8051
 ```
 
@@ -59,7 +59,7 @@ the pseudo-registers or updating 'asm.cpu', memory will be (re)allocated
 automatically when the analyzer is invoked the next time (e.g. during 'aei').
 Use the 'om' command to see the list of allocated memory blocks.
 
-```sh
+```console
 [0x00000000]> e asm.cpu=8051.generic
 [0x00000000]> aei
 [0x00000000]> om

--- a/src/arch/decompile.md
+++ b/src/arch/decompile.md
@@ -24,7 +24,7 @@ You may find it's output quite verbose and noisy, but handy and fast, and that s
 
 Another benefit of `pdc` is that it is available for ALL architectures supported by r2.
 
-```
+```console
 [0x100003a48]> pdc
 int sym.func.100003a48 (int x0, int x1) {
         x8 = [x0 + 0x60]  // arg1
@@ -55,7 +55,7 @@ This decompiler is available via `r2pm` and is sits after the `pdd` command. It 
 
 This plugin can be configured with the `e r2dec.` variables:
 
-```
+```console
 [0x00000000]> e??r2dec.
        r2dec.asm: if true, shows pseudo next to the assembly.
     r2dec.blocks: if true, shows only scopes blocks.
@@ -70,7 +70,7 @@ This plugin can be configured with the `e r2dec.` variables:
 
 In this example we show how `pdda` works, displaying the two columns:
 
-```
+```console
 [0x100003a48]> pdda
 ; assembly                     | /* r2dec pseudo code output */
                                | /* /bin/ls @ 0x100003a48 */
@@ -110,7 +110,7 @@ Note that the quality of the decompilation of r2ghidra compared to ghidra is not
 
 The plugin can be configured with the `e r2ghidra.` variables:
 
-```
+```console
 [0x00000000]> e??r2ghidra.
       r2ghidra.casts: Show type casts where needed
     r2ghidra.cmt.cpp: C++ comment style
@@ -130,7 +130,7 @@ The plugin can be configured with the `e r2ghidra.` variables:
 
 In this example we see how `pdgo` works, displaying the
 
-```
+```console
 [0x100003a48]> pdgo
 0x100003a48 |ulong sym.func.100003a48(int64_t param_1, int64_t param_2) {
             |    ulong uVar1;

--- a/src/arch/intro.md
+++ b/src/arch/intro.md
@@ -8,13 +8,13 @@ It was a working and unix friendly solution, but it was inefficient as it repeat
 
 So there was a need to create a generic disassembler library to support multiple plugins for different architectures. We can list the current loaded plugins with
 
-```
+```console
 $ rasm2 -L
 ```
 
 Or from inside radare2:
 
-```
+```console
 > e asm.arch=??
 ```
 
@@ -24,7 +24,7 @@ Nowadays, the disassembler support is one of the basic features of radare. It no
 
 To see the disassembly, use the `pd` command. It accepts a numeric argument to specify how many opcodes of current block you want to see. Most of the commands in radare consider the current block size as the default limit for data input. If you want to disassemble more bytes, set a new block size using the `b` command.
 
-```
+```console
 [0x00000000]> b 100    ; set block size to 100
 [0x00000000]> pd       ; disassemble 100 bytes
 [0x00000000]> pd 3     ; disassemble 3 opcodes
@@ -35,7 +35,7 @@ The `pD` command works like `pd` but accepts the number of input bytes as its ar
 
 The "pseudo" syntax may be somewhat easier for a human to understand than the default assembler notations. But it can become annoying if you read lots of code. To play with it:
 
-```
+```console
 [0x00405e1c]> e asm.pseudo = true
 [0x00405e1c]> pd 3
 		  ; JMP XREF from 0x00405dfa (fcn.00404531)

--- a/src/arch/metadata.md
+++ b/src/arch/metadata.md
@@ -5,13 +5,13 @@ Radare offers multiple ways to store and retrieve such metadata.
 
 By following common basic UNIX principles, it is easy to write a small utility in a scripting language which uses `objdump`, `otool` or any other existing utility to obtain information from a binary and to import it into radare. For example, take a look at `idc2r.py` shipped with [radare2ida](https://github.com/radareorg/radare2-extras/tree/master/r2ida). To use it, invoke it as `idc2r.py file.idc > file.r2`. It reads an IDC file exported from an IDA Pro database and produces an r2 script containing the same comments, names of functions and other data. You can import the resulting 'file.r2' by using the dot `.` command of radare:
 
-```
+```console
 [0x00000000]> . file.r2
 ```
 
 The `.` command is used to interpret Radare commands from external sources, including files and program output. For example, to omit generation of an intermediate file and import the script directly you can use this combination:
 
-```
+```console
 [0x00000000]> .!idc2r.py < file.idc
 ```
 
@@ -23,7 +23,7 @@ The `C` command is used to manage comments and data conversions. You can define 
 
 There are many different metadata manipulation commands, here is the glimpse of all of them:
 
-```
+```console
 [0x00404cc0]> C?
 | Usage: C[-LCvsdfm*?][*?] [...]   # Metadata management
 | C                                              list meta info in human friendly form
@@ -55,7 +55,7 @@ There are many different metadata manipulation commands, here is the glimpse of 
 
 Simply to add the comment to a particular line/address you can use `Ca` command:
 
-```
+```console
 [0x00000000]> CCa 0x0000002 this guy seems legit
 [0x00000000]> pd 2
 0x00000000    0000         add [rax], al
@@ -67,14 +67,14 @@ The `C?` family of commands lets you mark a range as one of several kinds of typ
 
 Annotating data types is most easily done in visual mode, using the "d" key, short for "data type change". First, use the cursor to select a range of bytes (press `c` key to toggle cursor mode and use HJKL keys to expand selection), then press 'd' to get a menu of possible actions/types. For example, to mark the range as a string, use the 's' option from the menu. You can achieve the same result from the shell using the `Cs` command:
 
-```
+```console
 [0x00000000]> f string_foo @ 0x800
 [0x00000000]> Cs 10 @ string_foo
 ```
 
 The `Cf` command is used to define a memory format string (the same syntax used by the `pf` command). Here's an example:
 
-```
+```console
 [0x7fd9f13ae630]> Cf 16 2xi foo bar
 [0x7fd9f13ae630]> pd
 ;-- rip:
@@ -104,7 +104,7 @@ create a link for a particular text file. You can use it with `CC,` command or b
 the visual mode. This will open an `$EDITOR` to create a new file, or if filename does exist, just
 will create a link. It will be shown in the disassembly comments:
 
-```
+```console
 [0x00003af7 11% 290 /bin/ls]> pd $r @ main+55 # 0x3af7
 |0x00003af7  call sym.imp.setlocale        ;[1] ; ,(locale-help.txt) ; char *setlocale(int category, const char *locale)
 |0x00003afc  lea rsi, str.usr_share_locale ; 0x179cc ; "/usr/share/locale"

--- a/src/commandline/block_size.md
+++ b/src/commandline/block_size.md
@@ -2,7 +2,7 @@
 
 The block size determines how many bytes radare2 commands will process when not given an explicit size argument. You can temporarily change the block size by specifying a numeric argument to the print commands. For example `px 20`.
 
-```
+```console
 [0x00000000]> b?
 Usage: b[f] [arg]  # Get/Set block size
 | b 33     set block size to 33
@@ -18,7 +18,7 @@ Usage: b[f] [arg]  # Get/Set block size
 
 The `b` command is used to change the block size:
 
-```
+```console
 [0x00000000]> b 0x100   # block size = 0x100
 [0x00000000]> b+16      #  ... = 0x110
 [0x00000000]> b-32      #  ... = 0xf0
@@ -26,20 +26,20 @@ The `b` command is used to change the block size:
 
 The `bf` command is used to change the block size to value specified by a flag. For example, in symbols, the block size of the flag represents the size of the function. To make that work, you have to either run function analysis `af` (which is included in `aa`) or manually seek and define some functions e.g. via `Vd`.
 
-```
+```console
 [0x00000000]> bf sym.main    # block size = sizeof(sym.main)
 [0x00000000]> pD @ sym.main  # disassemble sym.main
 ```
 
 You can combine two operations in a single `pdf` command. Except that `pdf` neither uses nor affects global block size.
 
-```
+```console
 [0x00000000]> pdf @ sym.main  # disassemble sym.main
 ```
 
 Another way around is to use special variables `$FB` and `$FS` which denote Function's Beginning and Size at the current seek. Read more about [Usable variables](../refcard/intro.md#usable-variables-in-expression).
 
-```
+```console
 [0x00000000]> s sym.main + 0x04
 [0x00001ec9]> pD @ $FB !$FS  # disassemble current function
 / 211: int main (int argc, char **argv, char **envp);

--- a/src/commandline/cmp_watchers.md
+++ b/src/commandline/cmp_watchers.md
@@ -3,7 +3,7 @@
 Watchers are used to record memory at 2 different points in time, then report
 if and how it changed.
 
-```
+```console
 [0x00000000]> cw?
 Usage: cw [args]  Manage compare watchers; See if and how memory changes
 | cw??            Show more info about watchers
@@ -19,7 +19,7 @@ Usage: cw [args]  Manage compare watchers; See if and how memory changes
 First, create one with `cw addr sz cmd`. This will record `sz` bytes at `addr`.
 The command is stored and used to print the memory when shown.
 
-```
+```console
 # Create a watcher at 0x0 of size 4 using p8 as the command
 [0x00000000]> cw 0 4 p8
 ```
@@ -29,7 +29,7 @@ report if the bytes changed and run the command given at creation with the size
 and address. When an address is an optional argument, the command will apply
 to all watchers if you don't pass one.
 
-```
+```console
 # Introduce a change to the block of data we're watching
 [0x00000000]> wx 11223344
 # Update all watchers
@@ -43,7 +43,7 @@ to all watchers if you don't pass one.
 You may overwrite any watcher by creating another at the same address. This
 will discard the existing watcher completely.
 
-```
+```console
 # Overwrite our existing watcher to display a bistream instead of
 # hexpairs, and make the watched area larger
 [0x00000000]> cw 0 8 pB
@@ -64,7 +64,7 @@ your new base state when updating with `cwu`. Any existing "new" state from
 running `cwu` previously is lost in this process. Showing a watcher without
 updating will still run the command, but it will not report changes.
 
-```
+```console
 # Create a basic watcher
 [0x00000000]> cw 0 4 p8
 [0x00000000]> cw
@@ -92,7 +92,7 @@ updating will still run the command, but it will not report changes.
 Watched memory areas may overlap with no ill effects, but may have unexpected
 results if you update some but not others.
 
-```
+```console
 # Create a watcher that watches 512 bytes starting at 0
 [0x00000000]> cw 0 0x200 p8
 # Create a watcher that watches 16 bytes starting at 0x100
@@ -116,7 +116,7 @@ cw 0x00000100 16 p8 # differs
 
 Here is an example of using a disassembly command to watch code being modified.
 
-```
+```console
 # Write an initial binary blob for the example
 [0x00000000]> wx 5053595a
 # Use pD since it counts by bytes

--- a/src/commandline/comparing_bytes.md
+++ b/src/commandline/comparing_bytes.md
@@ -2,7 +2,7 @@
 
 For most generic reverse engineering tasks like finding the differences between two binary files, which bytes has changed, find differences in the graphs of the code analysis results, and other diffing operations you can just use radiff2:
 
-```
+```console
 $ radiff2 -h
 ```
 
@@ -10,7 +10,7 @@ Inside r2, the functionalities exposed by radiff2 are available with the `c` com
 
 `c` (short for "compare") allows you to compare arrays of bytes from different sources. The command accepts input in a number of formats and then compares it against values found at current seek position.
 
-```
+```console
 [0x00404888]> c?
 Usage: c[?dfx] [argument]   # Compare
 | c [string]               Compare a plain with escaped chars string
@@ -40,7 +40,7 @@ Usage: c[?dfx] [argument]   # Compare
 
 To compare memory contents at current seek position against a given string of values, use `cx`:
 
-```
+```console
 [0x08048000]> p8 4
 7f 45 4c 46
 
@@ -53,19 +53,19 @@ Compare 3/4 equal bytes
 Another subcommand of the `c` command is `cc` which stands for "compare code".
 To compare a byte sequence with a sequence in memory:
 
-```
+```console
 [0x4A13B8C0]> cc 0x39e8e089 @ 0x4A13B8C0
 ```
 
 To compare contents of two functions specified by their names:
 
-```
+```console
 [0x08049A80]> cc sym.main2 @ sym.main
 ```
 
 `c8` compares a quadword from the current seek (in the example below, 0x00000000) against a math expression:
 
-```
+```console
 [0x00000000]> c8 4
 
 Compare 1/8 equal bytes (0%)
@@ -76,7 +76,7 @@ Compare 1/8 equal bytes (0%)
 
 The number parameter can, of course, be math expressions which use flag names and anything allowed in an expression:
 
-```
+```console
 [0x00000000]> cx 7f469046
 
 Compare 2/4 equal bytes
@@ -86,8 +86,8 @@ Compare 2/4 equal bytes
 
 You can use the compare command to find differences between a current block and a file previously dumped to a disk:
 
-```
-r2 /bin/true
+```console
+$ r2 /bin/true
 [0x08049A80]> s 0
 [0x08048000]> cf /bin/true
 Compare 512/512 equal bytes

--- a/src/commandline/flags.md
+++ b/src/commandline/flags.md
@@ -4,19 +4,19 @@ Flags are conceptually similar to bookmarks. They associate a name with a given 
 
 To create a flag:
 
-```
+```console
 [0x4A13B8C0]> f flag_name @ offset
 ```
 
 You can remove a flag by appending the `-` character to command. Most commands accept `-` as argument-prefix as an indication to delete something.
 
-```
+```console
 [0x4A13B8C0]> f-flag_name
 ```
 
 To switch between or create new flagspaces use the `fs` command:
 
-```
+```console
 [0x00005310]> fs?
 |Usage: fs [*] [+-][flagspace|addr] # Manage flagspaces
 | fs            display flagspaces
@@ -47,7 +47,7 @@ To switch between or create new flagspaces use the `fs` command:
 
 Here there are some command examples:
 
-```
+```console
 [0x4A13B8C0]> fs symbols ; select only flags in symbols flagspace
 [0x4A13B8C0]> f          ; list only flags in symbols flagspace
 [0x4A13B8C0]> fs *       ; select all flagspaces
@@ -62,7 +62,7 @@ You can rename flags with `fr`.
 Every flag name should be unique for addressing reasons. But it is quite a common need
 to have the flags, for example inside the functions, with simple and ubiquitous names like `loop` or `return`. For this purpose you can use so called "local" flags, which are tied to the function where they reside. It is possible to add them using `f.` command:
 
-```
+```console
 [0x00003a04]> pd 10
 |      0x00003a04      48c705c9cc21.  mov qword [0x002206d8], 0xffffffffffffffff ;
 [0x2206d8:8]=0
@@ -101,7 +101,7 @@ to have the flags, for example inside the functions, with simple and ubiquitous 
 
 radare2 offers flag zones, which lets you label different offsets on the scrollbar, for making it easier to navigate through large binaries. You can set a flag zone on the current seek using:
 
-```
+```console
 [0x00003a04]> fz flag-zone-name
 ```
 

--- a/src/commandline/intro.md
+++ b/src/commandline/intro.md
@@ -10,26 +10,26 @@ The general format for a valid command (as explained in the [Command Format](../
 
 For example,
 
-```
+```console
 > 3s +1024    ; seeks three times 1024 from the current seek
 ```
 
 If a command starts with `=!`, the rest of the string is passed to the currently loaded IO plugin (a debugger, for example). Most plugins provide help messages with `=!?` or `=!help`.
 
-```
+```console
 $ r2 -d /bin/ls
 > =!help      ; handled by the IO plugin
 ```
 
 If a command starts with `!`, the POSIX `system()` C function is called to pass the command to your shell. Check `!?` for more options and usage examples.
 
-```
+```console
 > !ls         ; run `ls` in the shell
 ```
 
 The meaning of the arguments (iter, addr, size) depends on the specific command. As a rule of thumb, most commands take a number as an argument to specify the number of bytes to work with, instead of the currently defined block size. Some commands accept math expressions or strings.
 
-```
+```console
 > px 0x17     ; show 0x17 bytes in hexs at current seek
 > s base+0x33 ; seeks to flag 'base' plus 0x33
 > / lib       ; search for 'lib' string.
@@ -37,14 +37,14 @@ The meaning of the arguments (iter, addr, size) depends on the specific command.
 
 The `@` sign is used to specify a temporary offset location or a seek position at which the command is executed, instead of current seek position. This is quite useful as you don't have to seek around all the time.
 
-```
+```console
 > p8 10 @ 0x4010  ; show 10 bytes at offset 0x4010
 > f patata @ 0x10 ; set 'patata' flag at offset 0x10
 ```
 
 Using `@@` you can execute a single command on a list of flags matching the glob. You can think of this as a foreach operation:
 
-```
+```console
 > s 0
 > / lib             ; search 'lib' string
 > p8 20 @@ hit0_*   ; show 20 hexpairs at each search hit
@@ -52,14 +52,14 @@ Using `@@` you can execute a single command on a list of flags matching the glob
 
 The `>` operation is used to redirect the output of a command into a file (overwriting it if it already exists).
 
-```
+```console
 > pr > dump.bin   ; dump 'raw' bytes of current block to file named 'dump.bin'
 > f  > flags.txt  ; dump flag list to 'flags.txt'
 ```
 
 The `|` operation (pipe) is similar to what you are used to expect from it in a *NIX shell: an output of one command as input to another.
 
-```
+```console
 [0x4A13B8C0]> f | grep section | grep text
 0x0805f3b0 512 section._text
 0x080d24b0 512 section._text_end
@@ -67,13 +67,13 @@ The `|` operation (pipe) is similar to what you are used to expect from it in a 
 
 You can pass several commands in a single line by separating them with a semicolon `;`:
 
-```
+```console
 > px ; dr
 ```
 
 Using `_`, you can print the result that was obtained by the last command.
 
-```
+```console
 [0x00001060]> axt 0x00002004
 main 0x1181 [DATA] lea rdi, str.argv__2d_:__s
 [0x00001060]> _

--- a/src/commandline/mapping_files.md
+++ b/src/commandline/mapping_files.md
@@ -12,7 +12,7 @@ radare2 is able to open files and map portions of them at random places in memor
 
 Opening files (and mapping them) is done using the `o` (open) command. Let's read the help:
 
-```
+```console
 [0x00000000]> o?
 |Usage: o [com- ] [file] ([offset])
 | o                         list opened files
@@ -45,7 +45,7 @@ Opening files (and mapping them) is done using the `o` (open) command. Let's rea
 
 Prepare a simple layout:
 
-```sh
+```console
 $ rabin2 -l /bin/ls
 [Linked libraries]
 libselinux.so.1
@@ -58,13 +58,13 @@ libc.so.6
 
 Map a file:
 
-```
+```console
 [0x00001190]> o /bin/zsh 0x499999
 ```
 
 List mapped files:
 
-```
+```console
 [0x00000000]> o
 - 6 /bin/ls @ 0x0 ; r
 - 10 /lib/ld-linux.so.2 @ 0x100000000 ; r
@@ -73,18 +73,18 @@ List mapped files:
 
 Print hexadecimal values from /bin/zsh:
 
-```
+```console
 [0x00000000]> px @ 0x499999
 ```
 
 Unmap files using the `o-` command. Pass the required file descriptor to it as an argument:
 
-```
+```console
 [0x00000000]> o-14
 ```
 
 You can also view the ascii table showing the list of the opened files:
 
-```
+```console
 [0x00000000]> ob=
 ```

--- a/src/commandline/print_modes.md
+++ b/src/commandline/print_modes.md
@@ -6,7 +6,7 @@ Binary data can be represented as integers, shorts, longs, floats, timestamps, h
 
 Below is a list of available print modes listed by `p?`:
 
-```
+```console
 [0x00005310]> p?
 |Usage: p[=68abcdDfiImrstuxz] [arg|len] [@addr]
 | p[b|B|xb] [len] ([S])   bindump N bits skipping S bytes
@@ -47,7 +47,7 @@ Below is a list of available print modes listed by `p?`:
 
 Tip: when using json output, you can append the `~{}` to the command to get a pretty-printed version of the output:
 
-```
+```console
 [0x00000000]> oj
 [{"raised":false,"fd":563280,"uri":"malloc://512","from":0,"writable":true,"size":512,"overlaps":false}]
 [0x00000000]> oj~{}
@@ -78,7 +78,7 @@ For more on the magical powers of `~` see the help in `?@?`, and the [Command Fo
 
 #### 8 bits Hexpair List of Bytes
 
-```
+```console
 [0x00404888]> p8 16
 31ed4989d15e4889e24883e4f0505449
 ```
@@ -91,7 +91,7 @@ For more on the magical powers of `~` see the help in `?@?`, and the [Command Fo
 
 Currently supported timestamp output modes are:
 
-```
+```console
 [0x00404888]> pt?
 |Usage: pt [dn]  print timestamps
 | pt.  print current time
@@ -103,7 +103,7 @@ Currently supported timestamp output modes are:
 
 For example, you can 'view' the current buffer as timestamps in the ntfs time:
 
-```
+```console
 [0x08048000]> e cfg.bigendian = false
 [0x08048000]> pt 4
 29:04:32948 23:12:36 +0000
@@ -114,7 +114,7 @@ For example, you can 'view' the current buffer as timestamps in the ntfs time:
 
 As you can see, the endianness affects the result. Once you have printed a timestamp, you can grep the output, for example, by year:
 
-```
+```console
 [0x08048000]> pt ~1974 | wc -l
 15
 [0x08048000]> pt ~2022
@@ -146,7 +146,7 @@ The default date format can be configured using the `cfg.datefmt` variable. Form
 
 There are print modes available for all basic types. If you are interested in a more complex structure, type `pf??` for format characters and `pf???` for examples:
 
-```
+```console
 [0x00499999]> pf??
 |pf: pf[.k[.f[=v]]|[v]]|[n]|[0|cnt][fmt] [a0 a1 ...]
 | Format:
@@ -188,7 +188,7 @@ There are print modes available for all basic types. If you are interested in a 
 
 Use triple-question-mark `pf???` to get some examples using print format strings.
 
-```
+```console
 [0x00499999]> pf???
 |pf: pf[.k[.f[=v]]|[v]]|[n]|[0|cnt][fmt] [a0 a1 ...]
 | Examples:
@@ -219,12 +219,12 @@ Use triple-question-mark `pf???` to get some examples using print format strings
 
 Some examples are below:
 
-```
+```console
 [0x4A13B8C0]> pf i
 0x00404888 = 837634441
 ```
 
-```
+```console
 [0x4A13B8C0]> pf
 0x00404888 = 837634432.000000
 ```
@@ -258,7 +258,7 @@ If we need to create a .c file containing a binary blob, use the `pc` command, t
 
 We can also just temporarily override this block size by expressing it as an argument.
 
-```
+```console
 [0xB7F8E810]> pc 32
 #define _BUFFER_SIZE 32
 unsigned char buffer[_BUFFER_SIZE] = {
@@ -267,7 +267,7 @@ unsigned char buffer[_BUFFER_SIZE] = {
 
 That cstring can be used in many programming languages, not just C.
 
-```
+```console
 [0x7fcd6a891630]> pcs
 "\x48\x89\xe7\xe8\x68\x39\x00\x00\x49\x89\xc4\x8b\x05\xef\x16\x22\x00\x5a\x48\x8d\x24\xc4\x29\xc2\x52\x48\x89\xd6\x49\x89\xe5\x48\x83\xe4\xf0\x48\x8b\x3d\x06\x1a
 ```
@@ -276,7 +276,7 @@ That cstring can be used in many programming languages, not just C.
 
 Strings are probably one of the most important entry points when starting to reverse engineer a program because they usually reference information about functions' actions (asserts, debug or info messages...). Therefore, radare supports various string formats:
 
-```
+```console
 [0x00000000]> ps?
 |Usage: ps[bijqpsuwWxz+] [N]  Print String
 | ps       print string
@@ -296,7 +296,7 @@ Strings are probably one of the most important entry points when starting to rev
 
 Most strings are zero-terminated. Below there is an example using the debugger to continue the execution of a program until it executes the 'open' syscall. When we recover the control over the process, we get the arguments passed to the syscall, pointed by %ebx. In the case of the 'open' call, it is a zero terminated string which we can inspect using `psz`.
 
-```
+```console
 [0x4A13B8C0]> dcs open
 0x4a14fc24 syscall(5) open ( 0x4a151c91 0x00000000 0x00000000 ) = 0xffffffda
 [0x4A13B8C0]> dr
@@ -313,7 +313,7 @@ Most strings are zero-terminated. Below there is an example using the debugger t
 
 It is also possible to print various packed data types using the `pf` command:
 
-```
+```console
 [0xB7F08810]> pf xxS @ rsp
 0x7fff0d29da30 = 0x00000001
 0x7fff0d29da34 = 0x00000000
@@ -322,7 +322,7 @@ It is also possible to print various packed data types using the `pf` command:
 
 This can be used to look at the arguments passed to a function. To achieve this, simply pass a 'format memory string' as an argument to `pf`, and temporally change the current seek position/offset using `@`. It is also possible to define arrays of structures with `pf`. To do this, prefix the format string with a numeric value. You can also define a name for each field of the structure by appending them as a space-separated arguments list.
 
-```
+```console
 [0x4A13B8C0]> pf 2*xw pointer type @ esp
 0x00404888 [0] {
    pointer :
@@ -337,7 +337,7 @@ This can be used to look at the arguments passed to a function. To achieve this,
 
 A practical example for using `pf` on a binary of a GStreamer plugin:
 
-```
+```console
 $ radare2 /usr/lib/gstreamer-1.0/libgstflv.so
 [0x00006020]> aa; pdf @ sym.gst_plugin_flv_get_desc
 [x] Analyze all flags starting with sym. and entry0 (aa)
@@ -367,7 +367,7 @@ The `pd` command is used to disassemble code. It accepts a numeric value to spec
 * `d` : disassembly N opcodes   count of opcodes
 * `D` : asm.arch disassembler   bsize bytes
 
-```
+```console
 [0x00404888]> pd 1
 ;-- entry0:
 0x00404888    31ed         xor ebp, ebp
@@ -377,7 +377,7 @@ The `pd` command is used to disassemble code. It accepts a numeric value to spec
 
 The architecture flavor for the disassembler is defined by the `asm.arch` eval variable. You can use `e asm.arch=??` to list all available architectures.
 
-```
+```console
 [0x00005310]> e asm.arch=??
 _dAe  _8_16      6502        LGPL3   6502/NES/C64/Tamagotchi/T-1000 CPU
 _dAe  _8         8051        PD      8051 Intel CPU
@@ -409,7 +409,7 @@ _d__  _32        lanai       GPL3    LANAI
 
 There are multiple options which can be used to configure the output of the disassembler. All these options are described in `e? asm.`
 
-```
+```console
 [0x00005310]> e? asm.
 asm.anal: Analyze code and refs while disassembling (see anal.strings)
 asm.arch: Set the arch to be used by asm

--- a/src/commandline/sdb.md
+++ b/src/commandline/sdb.md
@@ -20,7 +20,7 @@ SDB supports:
 
 Let's create a database!
 
-```bash
+```console
 $ sdb d hello=world
 $ sdb d hello
 world
@@ -28,7 +28,7 @@ world
 
 Using arrays:
 
-```sh
+```console
 $ sdb - '[]list=1,2' '[0]list' '[0]list=foo' '[]list' '[+1]list=bar'
 1
 foo
@@ -40,7 +40,7 @@ bar
 
 Let's play with json:
 
-```sh
+```console
 $ sdb d g='{"foo":1,"bar":{"cow":3}}'
 $ sdb d g?bar.cow
 3
@@ -50,7 +50,7 @@ $ sdb - user='{"id":123}' user?id=99 user?id
 
 Using the command line without any disk database:
 
-```sh
+```console
 $ sdb - foo=bar foo a=3 +a -a
 bar
 4
@@ -69,7 +69,7 @@ a=3
 
 Remove the database
 
-```sh
+```console
 $ rm -f d
 ```
 
@@ -79,7 +79,7 @@ So, you can now do this inside your radare2 sessions!
 
 Let's take a simple binary, and check what is already _sdbized_.
 
-```
+```console
 $ cat test.c
 int main(){
 	puts("Hello world\n");
@@ -87,7 +87,7 @@ int main(){
 $ gcc test.c -o test
 ```
 
-```
+```console
 $ r2 -A ./test
 [0x08048320]> k **
 bin
@@ -96,7 +96,7 @@ syscall
 debug
 ```
 
-```
+```console
 [0x08048320]> k bin/**
 fd.6
 [0x08048320]> k bin/fd.6/*
@@ -105,7 +105,7 @@ archs=0:0:x86:32
 
 The file corresponding to the sixth file descriptor is a x86_32 binary.
 
-```
+```console
 [0x08048320]> k anal/meta/*
 meta.s.0x80484d0=12,SGVsbG8gd29ybGQ=
 [...]

--- a/src/commandline/sections.md
+++ b/src/commandline/sections.md
@@ -4,7 +4,7 @@ The concept of sections is tied to the information extracted from the binary. We
 
 Displaying information about sections:
 
-```
+```console
 [0x00005310]> iS
 [Sections]
 00 0x00000000     0 0x00000000     0 ----
@@ -35,13 +35,13 @@ om fd vaddr [size] [paddr] [rwx] [name]
 
 For Example:
 
-```
+```console
 [0x0040100]> om 4 0x00000100 0x00400000 0x0001ae08 rwx test
 ```
 
 You can also use `om` command to view information about mapped sections:
 
-```
+```console
 [0x00401000]> om
  6 fd: 4 +0x0001ae08 0x00000100 - 0x004000ff rwx test
  5 fd: 3 +0x00000000 0x00000000 - 0x0000055f r-- fmap.LOAD0
@@ -57,6 +57,6 @@ It is also possible to delete the mapped section using the `om-mapid` command.
 
 For Example:
 
-```
+```console
 [0x00401000]> om-6
 ```

--- a/src/commandline/seeking.md
+++ b/src/commandline/seeking.md
@@ -6,7 +6,7 @@ The argument is a math expression that can contain flag names, parenthesis, addi
 
 Some example commands:
 
-```
+```console
 [0x00000000]> s 0x10
 [0x00000010]> s+4
 [0x00000014]> s-
@@ -24,19 +24,19 @@ Instead of using just numbers, we can use complex expressions, or basic arithmet
 
 To do this, check the ?$? Help message which describes the internal variables that can be used in the expressions. For example, this is the same as doing s+4 .
 
-```
+```console
 [0x00000000]> s $$+4
 ```
 
 From the debugger (or when emulating) we can also use the register names as references. They are loaded as flags with the `.dr*` command, which happens under the hood.
 
-```
+```console
 [0x00000000]> s rsp+0x40
 ```
 
 Here's the full help of the `s` command. We will explain in more detail below.
 
-```
+```console
 [0x00000000]> s?
 Usage: s   # Help for the seek commands. See ?$? to see all variables
 | s               print current address
@@ -79,7 +79,7 @@ Usage: s   # Help for the seek commands. See ?$? to see all variables
 
 If you want to inspect the result of a math expression, you can evaluate it using the `?` command. Simply pass the expression as an argument. The result can be displayed in hexadecimal, decimal, octal or binary formats.
 
-```
+```console
 > ? 0x100+200
 0x1C8 ; 456d ; 710o ; 1100 1000
 ```
@@ -93,13 +93,13 @@ In the visual mode, you can press `u` (undo) or `U` (redo) inside the seek histo
 As a test file, let's use a simple `hello_world.c` compiled in Linux ELF format.
 After we compile it let's open it with radare2:
 
-```
+```console
 $ r2 hello_world
 ```
 
 Now we have the command prompt:
 
-```
+```console
 [0x00400410]>
 ```
 
@@ -112,14 +112,14 @@ such as hex, octal, binary or decimal.
 
 Seek to an address 0x0. An alternative command is simply `0x0`
 
-```
+```console
 [0x00400410]> s 0x0
 [0x00000000]>
 ```
 
 Print current address:
 
-```
+```console
 [0x00000000]> s
 0x0
 [0x00000000]>
@@ -129,14 +129,14 @@ There is an alternate way to print current position: `?v $$`.
 
 Seek N positions forward, space is optional:
 
-```
+```console
 [0x00000000]> s+ 128
 [0x00000080]>
 ```
 
 Undo last two seeks to return to the initial address:
 
-```
+```console
 [0x00000080]> s-
 [0x00000000]> s-
 [0x00400410]>
@@ -146,7 +146,7 @@ We are back at _0x00400410_.
 
 There's also a command to show the seek history:
 
-```
+```console
 [0x00400410]> s*
 f undo_3 @ 0x400410
 f undo_2 @ 0x40041a
@@ -160,7 +160,7 @@ f redo_0 @ 0x4005b4
 
 Another important `s` subcommand is the `s..` one which permits to seek to another address taking the higher nibbles of the current address as reference, this technique works great for kernel, aslr or large binaries where you really don't want to type different or large numbers everytime.
 
-```
+```console
 [0x100003a84]> s..00
 [0x100003a00]> s..3b00
 [0x100003b00]> s..0000
@@ -176,14 +176,14 @@ The r2 shell provides many ways to do this, that's because reading pointers from
 
 Use the `*` command, which acts like in C. It reads the the value from the given address (`$$` stands for current seek) and honors `asm.bits` and `cfg.bigendian`.
 
-```
+```console
 [0x004000c8]> s `*$$`
 [0x0040032e]>
 ```
 
 This is the help message from the * command, which can be used as an alias for `wv` to write a value or to read from memory like the brackets syntax would do on any math expression in r2:
 
-```
+```console
 [0x100003a84]> *
 Usage: *<addr>[=[0x]value]  Pointer read/write data/values
 | *entry0=cc           write trap in entrypoint
@@ -195,7 +195,7 @@ Usage: *<addr>[=[0x]value]  Pointer read/write data/values
 
 Note that * can be also expressed as a math expression using the brackets syntax:
 
-```
+```console
 [0x100003a84]> ?v [$$]
 0xa9ba6ffcd503237f
 [0x100003a84]>

--- a/src/commandline/types.md
+++ b/src/commandline/types.md
@@ -2,7 +2,7 @@
 
 Radare2 can also work with data types. You can use standard C data types or define your own using C. Currently, there is a support for structs, unions, function signatures, and enums.
 
-```
+```console
 [0x00000000]> t?
 Usage: t   # cparse types commands
 | t                          List all loaded types
@@ -48,7 +48,7 @@ You can View loaded types in r2 using `ts` for structures, `tu` for unions, `tf`
 
 You can also cast pointers to data types and view data in there accordingly with `tp`. EX:
 
-```
+```console
 [0x00400511]> tp person = 0x7fff170a46b0
        age : 0x7fff170a46b0 = 20
        name : (*0x4005b0) 0x7fff170a46b4 = My name

--- a/src/commandline/write.md
+++ b/src/commandline/write.md
@@ -11,7 +11,7 @@ r -10 @ 33  ; strip 10 bytes at offset 33
 
 Write bytes using the `w` command. It accepts multiple input formats like inline assembly, endian-friendly dwords, files, hexpair files, wide strings:
 
-```
+```console
 [0x00404888]> w?
 Usage: w[x] [str] [<file] [<<EOF] [@addr]  
 | w[1248][+-][n]       increment/decrement byte,word..
@@ -46,7 +46,7 @@ Usage: w[x] [str] [<file] [<<EOF] [@addr]
 
 Some examples:
 
-```
+```console
  [0x00000000]> wx 123456 @ 0x8048300
  [0x00000000]> wv 0x8048123 @ 0x8049100
  [0x00000000]> wa jmp 0x8048320
@@ -57,7 +57,7 @@ Some examples:
 The `wo` command (write over) has many subcommands, each combines the existing data with the new data using
 an operator. The command is applied to the current block. Supported operators include XOR, ADD, SUB...
 
-```
+```console
 [0x4A13B8C0]> wo?
 |Usage: wo[asmdxoArl24] [hexpairs] @ addr[:bsize]
 |Example:
@@ -84,7 +84,7 @@ an operator. The command is applied to the current block. Supported operators in
 
 It is possible to implement cipher-algorithms using radare core primitives and `wo`. A sample session performing xor(90) + add(01, 02):
 
-```
+```console
 [0x7fcd6a891630]> px
 - offset -       0 1  2 3  4 5  6 7  8 9  A B  C D  E F
 0x7fcd6a891630  4889 e7e8 6839 0000 4989 c48b 05ef 1622
@@ -138,12 +138,12 @@ This script will run the `?e ..` command in r2 and then write the string 'Hello'
 
 ### Applying rapatches
 
-```
+```console
 $ r2 -P rapatch.txt target-program.txt
 ```
 
 Or for scripted patching like `patch(1)`:
 
-```
+```console
 $ r2 -w -q -P rapatch.txt target-program.txt
 ```

--- a/src/commandline/yank_paste.md
+++ b/src/commandline/yank_paste.md
@@ -13,7 +13,7 @@ The yank operation will read N bytes (specified by the argument) into the clipbo
 
 You can yank/paste bytes in visual mode selecting them with the cursor mode (`Vc`) and then using the `y` and `Y` key bindings which are aliases for `y` and `yy` commands of the command-line interface.
 
-```
+```console
 [0x00000000]> y?
 Usage: y[ptxy] [len] [[@]addr]   # See wd? for memcpy, same as 'yf'.
 | y!              open cfg.editor to edit the clipboard
@@ -40,7 +40,7 @@ Usage: y[ptxy] [len] [[@]addr]   # See wd? for memcpy, same as 'yf'.
 
 Sample session:
 
-```
+```console
 [0x00000000]> s 0x100    ; seek at 0x100
 [0x00000100]> y 100      ; yanks 100 bytes from here
 [0x00000200]> s 0x200    ; seek 0x200
@@ -49,7 +49,7 @@ Sample session:
 
 You can perform a yank and paste in a single line by just using the `yt` command (yank-to). The syntax is as follows:
 
-```
+```console
 [0x4A13B8C0]> x
    offset   0 1  2 3  4 5  6 7  8 9  A B  0123456789AB
 0x4A13B8C0, 89e0 e839 0700 0089 c7e8 e2ff ...9........

--- a/src/commandline/zoom.md
+++ b/src/commandline/zoom.md
@@ -4,7 +4,7 @@ The zoom is a print mode that allows you to get a global view of the whole file 
 
 The cursor can be used to scroll faster through the zoom out view. Pressing `z` again will zoom-in at the cursor position.
 
-```
+```console
 [0x004048c5]> pz?
 |Usage: pz [len] print zoomed blocks (filesize/N)
 | e zoom.maxsz  max size of block
@@ -22,7 +22,7 @@ The cursor can be used to scroll faster through the zoom out view. Pressing `z` 
 
 Let's see some examples:
 
-```
+```console
 [0x08049790]> e zoom.byte=h
 [0x08049790]> pz // or default pzh
 0x00000000  7f00 0000 e200 0000 146e 6f74 0300 0000
@@ -33,7 +33,7 @@ Let's see some examples:
 0x00000050  7500 00e1 ffe8 58fe 4dc4 00e0 dbc8 b885
 ```
 
-```
+```console
 [0x08049790]> e zoom.byte=p
 [0x08049790]> pz // or pzp
 0x00000000  2f47 0609 070a 0917 1e9e a4bd 2a1b 2c27
@@ -44,7 +44,7 @@ Let's see some examples:
 0x00000050  7d66 625f 7ea4 7ea6 b4b6 8b57 a19f 71a2
 ```
 
-```
+```console
 [0x08049790]> eval zoom.byte = flags
 [0x08049790]> pz // or pzf
 0x00406e65  48d0 80f9 360f 8745 ffff ffeb ae66 0f1f
@@ -56,7 +56,7 @@ Let's see some examples:
 0x00406ec5  c001 4983 c201 4983 c101 e9ec feff ff0f
 ```
 
-```
+```console
 [0x08049790]> e zoom.byte=F
 [0x08049790]> pO // or pzF
 0x00000000  0000 0000 0000 0000 0000 0000 0000 0000
@@ -69,7 +69,7 @@ Let's see some examples:
 
 You can limit zooming to a range of bytes instead of the whole bytespace. Change `zoom.from` and `zoom.to` eval variables:
 
-```
+```console
 [0x00003a04]> e? zoom.
 zoom.byte: Zoom callback to calculate each byte (See pz? for help)
 zoom.from: Zoom start address

--- a/src/config/colors.md
+++ b/src/config/colors.md
@@ -4,7 +4,7 @@ Console access is wrapped in API that permits to show the output of any command 
 
 To enable colors support by default, add a corresponding configuration option to the .radare2 configuration file:
 
-```
+```console
 $ echo 'e scr.color=1' >> ~/.radare2rc
 ```
 

--- a/src/config/intro.md
+++ b/src/config/intro.md
@@ -6,7 +6,7 @@ To prevent radare2 from parsing this file at startup, pass it the `-N` option.
 
 All the configuration of radare2 is done with the `eval` commands. A typical startup configuration file looks like this:
 
-```sh
+```console
 $ cat ~/.radare2rc
 e scr.color = 1
 e dbg.bep   = loader
@@ -14,7 +14,7 @@ e dbg.bep   = loader
 
 The configuration can also be changed with `-e` <config=value> command-line option. This way you can adjust configuration from the command line, keeping the .radare2rc file intact. For example, to start with empty configuration and then adjust `scr.color` and `asm.syntax` the following line may be used:
 
-```sh
+```console
 $ radare2 -N -e scr.color=1 -e asm.syntax=intel -d /bin/ls
 ```
 
@@ -78,7 +78,7 @@ A simpler alternative to the `e` command is accessible from the visual mode. Typ
 For configuration values that can take one of several values, you can use the `=?` operator to get a list
 of valid values:
 
-```
+```console
 [0x00000000]> e scr.nkey = ?
 scr.nkey = fun, hit, flag
 ```

--- a/src/config/io.md
+++ b/src/config/io.md
@@ -2,7 +2,7 @@
 
 The IO implementation is very complex and can be configured in many ways to serve the way the user needs. This chapter will introduce you to some of the most important configuration options under the eval.
 
-```
+```console
 [0x100003a84]> e??io.
              io.0xff: use this value instead of 0xff to fill unallocated areas
              io.aslr: disable ASLR for spawn and such

--- a/src/crackmes/avatao/first_steps.md
+++ b/src/crackmes/avatao/first_steps.md
@@ -3,7 +3,7 @@
 OK, enough of praising r2, lets start reversing this stuff. First, you have to
 know your enemy:
 
-```
+```console
 [0x00 avatao]$ rabin2 -I reverse4
 pic      false
 canary   true
@@ -36,7 +36,7 @@ binsz    8620
 So, its a dynamically linked, stripped, 64bit Linux executable - nothing fancy
 here. Let's try to run it:
 
-```
+```console
 [0x00 avatao]$ ./reverse4
 ?
 Size of data: 2623
@@ -53,7 +53,7 @@ either "Wrong!", nothing or something else, presumably our flag. But do not
 waste any more time monkeyfuzzing the executable, let's fire up r2, because in
 asm we trust!
 
-```
+```console
 [0x00 avatao]$ r2 -A reverse4
  -- Heisenbug: A bug that disappears or alters its behavior when one attempts to probe or isolate it.
 [0x00400720]>
@@ -66,7 +66,7 @@ asm we trust!
 It is a good practice to create a project, so we can save our progress, and we
 can come back at a later time:
 
-```
+```console
 [0x00400720]> Ps avatao_reverse4
 avatao_reverse4
 [0x00400720]>
@@ -77,7 +77,7 @@ avatao_reverse4
 
 We can list all the strings r2 found:
 
-```
+```console
 [0x00400720]> fs strings
 [0x00400720]> f
 0x00400e98 7 str.Wrong_
@@ -107,7 +107,7 @@ be solved. So I usually just take a look at the entry point(s) and see if I can
 figure out something from there. Nevertheless, I'll show you how to find where
 these strings are used:
 
-```
+```console
 [0x00400720]> axt @@=`f~[0]`
 d 0x400cb5 mov edi, str.Size_of_data:__u_n
 d 0x400d1d mov esi, str.Such_VM__MuCH_reV3rse_

--- a/src/crackmes/avatao/main.md
+++ b/src/crackmes/avatao/main.md
@@ -3,7 +3,7 @@
 As I was saying, I usually take a look at the entry point, so let's just do
 that:
 
-```
+```console
 [0x00400720]> s main
 [0x00400c63]>
 ```
@@ -52,7 +52,7 @@ Lets read main node-by-node! The first block looks like this:
 We can see that the program reads a word (2 bytes) into the local variable named
 _local_10_6_, and than compares it to 0xbb8. That's 3000 in decimal:
 
-```
+```console
 [0x00400c63]> ? 0xbb8
 3000 0xbb8 05670 2.9K 0000:0bb8 3000 10111000 3000.0 0.000000f 0.000000
 ```
@@ -73,7 +73,7 @@ So now we know that the local variable _local_10_6_ is the size of the input
 data - so lets name it accordingly (remember, you can open the r2 shell from
 visual mode using the _:_ key!):
 
-```
+```console
 :> afvn local_10_6 input_size
 ```
 
@@ -87,7 +87,7 @@ After this an _input_size_ bytes long memory chunk is allocated, and filled with
 data from the standard input. The address of this memory chunk is stored in
 _local_10_ - time to use _afvn_ again:
 
-```
+```console
 :> afvn local_10 input_data
 ```
 
@@ -96,7 +96,7 @@ First, an 512 (0x200) bytes memory chunk is zeroed out at offset 0x00602120.
 A quick glance at XREFS to this address reveals that this memory is indeed used
 somewhere in the application:
 
-```
+```console
 :> axt 0x00602120
 d 0x400cfe mov edi, 0x602120
 d 0x400d22 mov edi, 0x602120
@@ -106,7 +106,7 @@ d 0x400a51 mov qword [rbp - 8], 0x602120
 
 Since it probably will be important later on, we should label it:
 
-```
+```console
 :> f sym.memory 0x200 0x602120
 ```
 
@@ -118,7 +118,7 @@ Since it probably will be important later on, we should label it:
 While we are here, we should also declare that memory chunk as data, so it will
 show up as a hexdump in disassembly view:
 
-```
+```console
 :> Cd 0x200 @ sym.memory
 ```
 
@@ -139,7 +139,7 @@ _input_data_ to _bytecode_ and _input_size_ to _bytecode_length_. This is not
 really necessary in a small project like this, but it's a good practice to name
 stuff according to their purpose (just like when you are writing programs).
 
-```
+```console
 :> af vmloop 0x400a45
 :> afvn input_size bytecode_length
 :> afvn input_data bytecode
@@ -192,7 +192,7 @@ on the result:
 It's pretty obvious that _local_10_4_ is the loop counter, so lets name it
 accordingly:
 
-```
+```console
 :> afvn local_10_4 i
 ```
 
@@ -215,7 +215,7 @@ we are dealing with a virtual machine. In that context, this message probably
 means that we have to use every available instructions. Whether we executed an
 instruction or not is stored at 0x6020e0 - so lets flag that memory area:
 
-```
+```console
 :> f sym.instr_dirty 4*9 0x6020e0
 ```
 
@@ -230,7 +230,7 @@ where offsets are described as displacements from the current instruction
 pointer, which makes implementing PIE easier. Anyways, r2 is nice enough to
 display the actual address (0x602104). Got the address, flag it!
 
-```
+```console
 :> f sym.good_if_ne_zero 4 0x602104
 ```
 
@@ -252,7 +252,7 @@ if it's lesser, or equal to 9, we finally reach our destination, and get the fla
 
 As usual, we should flag 0x6020f0:
 
-```
+```console
 :> f sym.good_if_le_9 4 0x6020f0
 ```
 

--- a/src/crackmes/avatao/radare2.md
+++ b/src/crackmes/avatao/radare2.md
@@ -31,7 +31,7 @@ functionality - and they are very well documented. I encourage you to read the
 available docs, and use the built-in help (by appending a ? to any command)
 extensively! E.g.:
 
-```
+```console
 [0x00000000]> ?
 Usage: [.][times][cmd][~grep][@[@iter]addr!size][|>pipe] ; ...
 Append '?' to any char command to get detailed help

--- a/src/crackmes/ioli/ioli_0x00.md
+++ b/src/crackmes/ioli/ioli_0x00.md
@@ -4,7 +4,7 @@ This first challenge is designed to introduce you to the basics of reverse engin
 
 By executing the program you may see something like this:
 
-```
+```console
 $ ./crackme0x00
 IOLI Crackme Level 0x00
 Password: 1234
@@ -76,7 +76,7 @@ What about this string? It hasn’t appeared when running the application yet.
 
 Let’s try using it as the password.
 
-```
+```console
 $ ./crackme0x00
 IOLI Crackme Level 0x00
 Password: 250382

--- a/src/crackmes/ioli/ioli_0x01.md
+++ b/src/crackmes/ioli/ioli_0x01.md
@@ -2,7 +2,7 @@
 
 This second challenge is designed to introduce you to more advanced reverse engineering techniques using Radare2. The objective is to find the correct password to unlock the program by examining the binary’s disassembly.
 
-```
+```console
 $ ./crackme0x01
 IOLI Crackme Level 0x01
 Password: test
@@ -47,7 +47,7 @@ Now it's probably a good time to make another blind guess trying the value by ru
 
 Let's go step by step to solve the second IOLI crackme. We can start by trying what we learned in the previous challenge by listing the strings with `rabin2`:
 
-```
+```console
 $ rabin2 -z ./crackme0x01
 [Strings]
 nth paddr      vaddr      len size section type  string
@@ -60,7 +60,7 @@ nth paddr      vaddr      len size section type  string
 
 This isn't going to be as easy as 0x00. Let's try disassembly with r2.
 
-```
+```console
 $ r2 ./crackme0x01 
 [0x08048330]> aa
 INFO: Analyze all flags starting with sym. and entry0 (aa)
@@ -116,14 +116,14 @@ This will print the disassembly of the main function, or the `main()` that every
 
 If you look carefully, you'll see a `cmp` instruction, with a constant, 0x149a. `cmp` is an x86 compare instruction, and the 0x in front of it specifies it is in base 16, or hex (hexadecimal).
 
-```
+```console
 [0x08048330]> pdf@main~cmp
 0x0804842b    817dfc9a140. cmp dword [ebp + 0xfffffffc], 0x149a
 ```
 
 You can use radare2's `?` command to display 0x149a in another numeric base.
 
-```
+```console
 [0x08048330]> ? 0x149a
 int32   5274
 uint32  5274
@@ -141,7 +141,7 @@ trits   0t21020100
 
 So now we know that 0x149a is 5274 in decimal. Let's try this as a password.
 
-```
+```console
 $ ./crackme0x01
 IOLI Crackme Level 0x01
 Password: 5274
@@ -150,7 +150,7 @@ Password OK :)
 
 Bingo, the password was 5274. In this case, the password function at 0x0804842b was comparing the input against the value, 0x149a in hex. Since user input is usually decimal, it was a safe bet that the input was intended to be in decimal, or 5274. Now, since we're hackers, and curiosity drives us, let's see what happens when we input in hex.
 
-```
+```console
 $ ./crackme0x01
 IOLI Crackme Level 0x01
 Password: 0x149a

--- a/src/crackmes/ioli/ioli_0x02.md
+++ b/src/crackmes/ioli/ioli_0x02.md
@@ -2,7 +2,7 @@
 
 This is the third one.
 
-```
+```console
 $ ./crackme0x02
 IOLI Crackme Level 0x02
 Password: hello
@@ -11,7 +11,7 @@ Invalid Password!
 
 check it with rabin2.
 
-```
+```console
 $ rabin2 -z ./crackme0x02
 [Strings]
 nth paddr      vaddr      len size section type  string
@@ -24,7 +24,7 @@ nth paddr      vaddr      len size section type  string
 
 similar to 0x01, no explicit password string here. so it's time to analyze it with r2.
 
-```
+```console
 [0x08048330]> aa
 [x] Analyze all flags starting with sym. and entry0 (aa)
 [0x08048330]> pdf@main
@@ -77,7 +77,7 @@ similar to 0x01, no explicit password string here. so it's time to analyze it wi
 
 with the experience of solving crackme0x02, we first locate the position of `cmp` instruction by using this simple oneliner:
 
-```
+```console
 [0x08048330]> pdf@main | grep cmp
 |           0x0804844e      3b45f4         cmp eax, dword [var_ch]
 ```
@@ -99,7 +99,7 @@ we can easily get the value of eax. it's 0x16.
 
 It gets hard when the scale of program grows. radare2 provides a pseudo disassembler output in C-like syntax. It may be useful.
 
-```
+```console
 [0x08048330]> pdc@main
 function main () {
     //  4 basic blocks
@@ -164,13 +164,13 @@ function main () {
 
 The `pdc` command is unreliable especially in processing loops (while, for, etc.). So I prefer to use the [r2dec](https://github.com/radareorg/r2dec-js) plugin in r2 repo to generate the pseudo C code. you can install it easily:
 
-```
+```sh
 r2pm install r2dec
 ```
 
 decompile `main()` with the following command (like `F5` in IDA):
 
-```C
+```c
 [0x08048330]> pdd@main
 /* r2dec pseudo code output */
 /* ./crackme0x02 @ 0x80483e4 */
@@ -216,7 +216,7 @@ we can:
 * seek
 * print string
 
-```
+```console
 [0x08048330]> s 0x804856c
 [0x0804856c]> ps
 %d
@@ -226,7 +226,7 @@ it's exactly the format string of `scanf()`. But r2dec does not recognize the se
 
 we can easily write out pseudo code here.
 
-```C
+```c
 var_ch = (var_8h + var_ch)^2;
 if (var_ch == our_input)
   printf("Password OK :)\n");
@@ -235,7 +235,7 @@ if (var_ch == our_input)
 given the initial status that var_8h is 0x5a, var_ch is 0x1ec, we have
 var_ch = 338724 (0x52b24):
 
-```
+```console
 $ rax2 '=10' '(0x5a+0x1ec)*(0x5a+0x1ec)' 
 338724
 

--- a/src/crackmes/ioli/ioli_0x03.md
+++ b/src/crackmes/ioli/ioli_0x03.md
@@ -2,7 +2,7 @@
 
 crackme 0x03, let's skip the string check part and analyze it directly.
 
-```C
+```c
 [0x08048360]> aaa
 [0x08048360]> pdd@sym.main
 /* r2dec pseudo code output */
@@ -54,8 +54,8 @@ int32_t main (void) {
 
 Here comes the`sym.test`, called with two parameters. One is var_4h (our input from `scanf()`). The other is var_ch. The value of var_ch (as the parameter of `test()`) can be calculated like it did in crackme_0x02. It's  0x52b24. Try it!
 
-```sh
-./crackme0x03
+```console
+$ ./crackme0x03
 IOLI Crackme Level 0x03
 Password: 338724
 Password OK!!! :)
@@ -136,7 +136,7 @@ print(''.join([chr(ord(i)-0x3) for i in 'LqydolgSdvvzrug$']))
 
 the easier way is to `run` the decryption code, that means debug it or emulate it. I used radare2 ESIL emulator but it got stuck when executed `call dword imp.strlen`. And I can't find the usage of hooking function / skip instruction in radare2.  The following is an example to show u how to emulate ESIL.
 
-```sh
+```console
 [0x08048414]> s 0x08048445		# the 'sub al, 0x03'
 [0x08048445]> aei				# init VM
 [0x08048445]> aeim				# init memory
@@ -181,8 +181,8 @@ dead at 0x00000000
 
 By the way, u can also open the file and use write data command to decrypt data.
 
-```sh
-r2 -w ./crackme0x03
+```console
+$ r2 -w ./crackme0x03
 [0x08048360]> aaa
 [0x08048360]> fs strings
 [0x08048360]> f

--- a/src/crackmes/ioli/ioli_0x04.md
+++ b/src/crackmes/ioli/ioli_0x04.md
@@ -1,6 +1,6 @@
 ### IOLI 0x04
 
-```C
+```c
 [0x080483d0]> pdd@main
 /* r2dec pseudo code output */
 /* ./crackme0x04 @ 0x8048509 */
@@ -27,7 +27,7 @@ int32_t main (void) {
 
 Let's enter check.
 
-```C
+```c
 #include <stdint.h>
 
 int32_t check (char * s) {
@@ -70,7 +70,7 @@ label_0:
 
 manually analyze with both the assembly and pseudo code we can simply write down the C-like code to describe this function:
 
-```C
+```c
 #include <stdint.h>
 int32_t check(char *s)
 {
@@ -91,13 +91,13 @@ int32_t check(char *s)
 
 In short, it calculates the Digit Sum of a number (add a number digit by digit. for example, 96 => 9 + 6 = 15) :
 
-```sh
-./crackme0x04
+```console
+$ ./crackme0x04
 IOLI Crackme Level 0x04
 Password: 12345
 Password OK!
 
-./crackme0x04
+$ ./crackme0x04
 IOLI Crackme Level 0x04
 Password: 96
 Password OK!

--- a/src/crackmes/ioli/ioli_0x05.md
+++ b/src/crackmes/ioli/ioli_0x05.md
@@ -2,7 +2,7 @@
 
 check again, it uses `scanf()` to get our input and pass it to `check()` as parameter.
 
-```C
+```c
 [0x080483d0]> pdd@main
 /* r2dec pseudo code output */
 /* ./crackme0x05 @ 0x8048540 */
@@ -29,7 +29,7 @@ int32_t main (void) {
 
 the check() function:
 
-```C
+```c
 /* r2dec pseudo code output */
 /* ./crackme0x05 @ 0x80484c8 */
 #include <stdint.h>
@@ -74,7 +74,7 @@ label_0:
 
 The same, we can write our own C-like pseudo code.
 
-```C
+```c
 #include <stdint.h>
 int32_t check(char *s)
 {
@@ -95,7 +95,7 @@ int32_t check(char *s)
 
 The if condition becomes `var_8h == 0x10`. In addition, a new function call - `parell(s)` replace the `printf("password OK")`now. The next step is to reverse sym.parell.
 
-```C
+```c
 [0x08048484]> s sym.parell
 [0x08048484]> pdd@sym.parell
 /* r2dec pseudo code output */
@@ -143,7 +143,7 @@ The `mov dword [esp], eax` is the nearest instruction to sscanf (and it's equiva
 
 Finally we have the corrected pseudo code:
 
-```C
+```c
 uint32_t parell (char * s) {
     sscanf (s, %d, &var_4h);
     if ((var_4h & 1) == 0) {
@@ -161,13 +161,13 @@ Now there are 2 constraints:
 
 The password is at our fingertips now.
 
-```sh
-./crackme0x05
+```console
+$ ./crackme0x05
 IOLI Crackme Level 0x05
 Password: 88
 Password OK!
 
-./crackme0x05
+$ ./crackme0x05
 IOLI Crackme Level 0x05
 Password: 12346
 Password OK!

--- a/src/crackmes/ioli/ioli_0x06.md
+++ b/src/crackmes/ioli/ioli_0x06.md
@@ -2,8 +2,8 @@
 
 nearly a routine to check this binary (not complete output in the following):
 
-```shell
-rabin2 -z ./crackme0x06
+```console
+$ rabin2 -z ./crackme0x06
 [Strings]
 nth paddr      vaddr      len size section type  string
 -------------------------------------------------------
@@ -13,7 +13,7 @@ nth paddr      vaddr      len size section type  string
 3   0x00000763 0x08048763 24  25   .rodata ascii IOLI Crackme Level 0x06\n
 4   0x0000077c 0x0804877c 10  11   .rodata ascii Password:
 
-rabin2 -I ./crackme0x06
+$ rabin2 -I ./crackme0x06
 arch     x86
 baddr    0x8048000
 bintype  elf
@@ -33,7 +33,7 @@ va       true
 
 and analyze it then decompile main
 
-```C
+```c
 [0x08048400]> pdd@main
 /* r2dec pseudo code output */
 /* ./crackme0x06 @ 0x8048607 */
@@ -64,7 +64,7 @@ int32_t main (int32_t arg_10h) {
 
 main has 3 arguments `argc, argv, envp`, and this program is compiled with GCC, so the stack should be like this :
 
-```sh
+```
 [esp + 0x10] - envp
 [esp + 0x0c] - argv
 [esp + 0x08] - argc
@@ -73,7 +73,7 @@ main has 3 arguments `argc, argv, envp`, and this program is compiled with GCC, 
 
 enter the `check()` and decompile it. this function is different from 0x05 now. but they still have similar code structure.
 
-```C
+```c
 int32_t check (char * s, int32_t arg_ch) {
     char * var_dh;
     uint32_t var_ch;
@@ -115,7 +115,7 @@ label_0:
 
 Correct the `sscanf` part and `parell` part, both of them were generated incorrectly:
 
-```C
+```c
 int32_t check (char * s, void* envp)
 {
     var_ch = 0;
@@ -135,7 +135,7 @@ int32_t check (char * s, void* envp)
 
  no more info, we have to reverse `parell()` again.
 
-```C
+```c
 #include <stdint.h>
 
 uint32_t parell (char * s, char * arg_ch) {
@@ -157,7 +157,7 @@ uint32_t parell (char * s, char * arg_ch) {
 
 well, there is a new check condition in `parell()` -- `dummy (var_4h, arg_ch) == 0`. then reverse dummy!
 
-```C
+```c
 [0x080484b4]> pdd@sym.dummy
 /* r2dec pseudo code output */
 /* ./crackme0x06 @ 0x80484b4 */
@@ -196,7 +196,7 @@ label_1:
 
 looks like a loop to process string. we can beautify it.
 
-```C
+```c
 [0x080484b4]> pdd@sym.dummy
 /* r2dec pseudo code output */
 /* ./crackme0x06 @ 0x80484b4 */
@@ -217,7 +217,7 @@ There are 3 constraints to crackme_0x06:
 * Odd Number
 * should have an environment variable whose name started with "LOL".
 
-```sh
+```console
 $ ./crackme0x06
 IOLI Crackme Level 0x06
 Password: 12346

--- a/src/crackmes/ioli/ioli_0x07.md
+++ b/src/crackmes/ioli/ioli_0x07.md
@@ -2,7 +2,7 @@
 
 a weird "wtf?" string.
 
-```sh
+```console
 $ rabin2 -z ./crackme0x07
 [Strings]
 nth paddr      vaddr      len size section type  string
@@ -29,7 +29,7 @@ int32_t main (int32_t arg_10h) {
 
 due to the symbol info lost, neither `aa` nor `aaa` show the name of functions. we can double check this in "flagspace". Radare2 use fcn_080485b9 as the function name. It's a common case in reverse engineering that we don't have any symbol info of the binary.
 
-```sh
+```console
 [0x080487fd]> fs symbols
 [0x080487fd]> f
 0x08048400 33 entry0
@@ -39,7 +39,7 @@ due to the symbol info lost, neither `aa` nor `aaa` show the name of functions. 
 
 decompile the `fcn_080485b9()`:
 
-```C
+```c
 [0x080485b9]> pdfc
             ; CALL XREF from main @ 0x80486d4
 / 118: fcn.080485b9 (char *s, int32_t arg_ch);
@@ -93,7 +93,7 @@ decompile the `fcn_080485b9()`:
 
 we got familiar with this code structure in the previous challenges (the check function). It's not difficult for us even we don't have the symbol info. you can also use `afn` command to rename the function name if you like.
 
-```C
+```c
 int32_t fcn_080485b9 (char * s, void* envp)
 {
     var_ch = 0;
@@ -112,7 +112,7 @@ int32_t fcn_080485b9 (char * s, void* envp)
 
 most part of crackme 0x07 is the same with 0x06. and it can be solved by the same password & environment:
 
-```sh
+```console
 $ export LOLAA=help
 $ ./cracke0x07
 IOLI Crackme Level 0x07
@@ -122,7 +122,7 @@ Password OK!
 
 wait ... where is the 'wtf?'. Often, we would like to find the cross reference (xref) to strings (or data, functions, etc.) in reverse engineering. The related commands in Radare2 are under "ax" namespace:
 
-```sh
+```console
 [0x08048400]> f
 0x080487a8 5 str.LOLO
 0x080487ad 21 str.Password_Incorrect
@@ -140,7 +140,7 @@ Macro 'findstref' removed.
 
 the `[DATA] mov dword [esp], str.wtf` at `0x804865c` is an instruction of fcn.080485b9. But the analysis in my PC ignores the remained instructions and only display the incomplete assembly. the range of fcn.080485b9 should be `0x080485b9 ~ 0x0804867c` . we can reset block size and print opcodes.
 
-```
+```console
 [0x08040000]> s 0x080485b9
 [0x080485b9]> b 230
 [0x08048400]> pd

--- a/src/crackmes/ioli/ioli_0x08.md
+++ b/src/crackmes/ioli/ioli_0x08.md
@@ -2,7 +2,7 @@
 
 we can reverse it and find it's similar to 0x07, and use the same password to solve it:
 
-```sh
+```console
 $ export LOLAA=help
 $ ./cracke0x08
 IOLI Crackme Level 0x08
@@ -12,7 +12,7 @@ Password OK!
 
 [dustri](https://dustri.org/b/defeating-ioli-with-radare2.html) provided a better way to check crackme0x08. 0x07 is the stripped version of 0x08.
 
-```sh
+```console
 $ radiff2 -A -C ./crackme0x07 ./crackme0x08
 ...
               fcn.08048360  23 0x8048360 |   MATCH  (1.000000) | 0x8048360   23 sym._init

--- a/src/crackmes/ioli/ioli_0x09.md
+++ b/src/crackmes/ioli/ioli_0x09.md
@@ -2,7 +2,7 @@
 
 Hints: crackme0x09 hides the format string (%d and %s), and nothing more than 0x08.
 
-```sh
+```console
 $ export LOLA=help 
 $ ./crackme0x09
 IOLI Crackme Level 0x09

--- a/src/credits/credits.md
+++ b/src/credits/credits.md
@@ -8,7 +8,7 @@ The original [radare book](http://www.radare.org/get/radare.pdf) was written by 
 
 Many thanks to everyone who have contributed to this book.
 
-```
+```console
 $ git log | grep ^Author | cut -d ':' -f 2- | cut -d '<' -f 1 | sort -u |xargs echo '* '
 ```
 

--- a/src/debugger/files.md
+++ b/src/debugger/files.md
@@ -8,7 +8,7 @@ So, at any time in the debugging session you can replace the stdio file descript
 
 This functionality is also available in r2frida by using the dd command prefixed with a backslash. In r2 you may want to see the output of dd? for proper details.
 
-```
+```console
 [0x00000000]> dd?
 Usage: dd  Manage file descriptors for child process (* to show r2 commands)
 | dd[*]                      list file descriptors

--- a/src/debugger/heap.md
+++ b/src/debugger/heap.md
@@ -2,7 +2,7 @@
 
 radare2's `dm` subcommands can also display a map of the heap which is useful for those who are interested in inspecting the heap and its content. Simply execute `dmh` to show a map of the heap:
 
-```
+```console
 [0x7fae46236ca6]> dmh
   Malloc chunk @ 0x55a7ecbce250 [size: 0x411][allocated]
   Top chunk @ 0x55a7ecbce660 - [brk_start: 0x55a7ecbce000, brk_end: 0x55a7ecbef000]
@@ -10,7 +10,7 @@ radare2's `dm` subcommands can also display a map of the heap which is useful fo
 
 You can also see a graph layout of the heap:
 
-```
+```console
 [0x7fae46236ca6]> dmhg
 Heap Layout
     .------------------------------------.
@@ -39,7 +39,7 @@ Heap Layout
 
 Another heap commands can be found under `dmh`, check `dmh?` for the full list.
 
-```
+```console
 [0x00000000]> dmh?
 |Usage:  dmh # Memory map heap
 | dmh                 List chunks in heap segment

--- a/src/debugger/intro.md
+++ b/src/debugger/intro.md
@@ -13,7 +13,7 @@ Process memory is treated as a plain file. All mapped memory pages of a debugged
 
 Communication between radare and the debugger IO layer is wrapped into `system()` calls, which accept a string as an argument, and executes it as a command. An answer is then buffered in the output console, its contents can be additionally processed by a script. Access to the IO system is achieved with `=!`. Most IO plugins provide help with `=!?` or `=!help`. For example:
 
-```
+```console
 $ r2 -d /bin/ls
 ...
 [0x7fc15afa3cc0]> =!help

--- a/src/debugger/memory_maps.md
+++ b/src/debugger/memory_maps.md
@@ -4,7 +4,7 @@ The ability to understand and manipulate the memory maps of a debugged program i
 
 First, let's see the help message for `dm`, the command which is responsible for handling memory maps:
 
-```
+```console
 [0x55f2104cf620]> dm?
 Usage: dm   # Memory maps commands
 | dm                               List memory maps of target process
@@ -34,7 +34,7 @@ In this chapter, we'll go over some of the most useful subcommands of `dm` using
 
 First things first - open a program in debugging mode:
 
-```
+```console
 $ r2 -d helloworld
 Process with PID 20304 started...
 = attach 20304 20304
@@ -48,7 +48,7 @@ asm.bits 64
 
 Let's use `dm` to print the memory maps of the binary we've just opened:
 
-```
+```console
 [0x7f133f022fb0]> dm
 0x0000563a0113a000 - usr   4K s r-x /tmp/helloworld /tmp/helloworld ; map.tmp_helloworld.r_x
 0x0000563a0133a000 - usr   8K s rw- /tmp/helloworld /tmp/helloworld ; map.tmp_helloworld.rw
@@ -65,14 +65,14 @@ For those of you who prefer a more visual way, you can use `dm=` to see the memo
 
 If you want to know the memory-map you are currently in, use `dm.`:
 
-```
+```console
 [0x7f133f022fb0]> dm.
 0x00007f947eed9000 # 0x00007f947eefe000 * usr   148K s r-x /usr/lib/ld-2.27.so /usr/lib/ld-2.27.so ; map.usr_lib_ld_2.27.so.r_x
 ```
 
 Using `dmm` we can "List modules (libraries, binaries loaded in memory)", this is quite a handy command to see which modules were loaded.
 
-```
+```console
 [0x7fa80a19dfb0]> dmm
 0x55ca23a4a000 /tmp/helloworld
 0x7fa80a19d000 /usr/lib/ld-2.27.so
@@ -82,7 +82,7 @@ Using `dmm` we can "List modules (libraries, binaries loaded in memory)", this i
 
 We can see that along with our `helloworld` binary itself, another library was loaded which is `ld-2.27.so`. We don't see `libc` yet and this is because radare2 breaks before `libc` is loaded to memory. Let's use `dcu` (**d**ebug **c**ontinue **u**ntil) to execute our program until the entry point of the program, which radare flags as `entry0`.
 
-```
+```console
 [0x7fa80a19dfb0]> dcu entry0
 Continue until 0x55ca23a4a520 using 1 bpsize
 hit breakpoint at: 55ca23a4a518
@@ -96,7 +96,7 @@ Now we can see that `libc-2.27.so` was loaded as well, great!
 
 Speaking of `libc`, a popular task for binary exploitation is to find the address of a specific symbol in a library. With this information in hand, you can build, for example, an exploit which uses ROP. This can be achieved using the `dmi` command. So if we want, for example, to find the address of [`system()`](http://man7.org/linux/man-pages/man3/system.3.html) in the loaded `libc`, we can simply execute the following command:
 
-```
+```console
 [0x55ca23a4a520]> dmi libc system
 514 0x00000000 0x7fa809de1000  LOCAL  FILE    0 system.c
 515 0x00043750 0x7fa809e24750  LOCAL  FUNC 1221 do_system
@@ -111,7 +111,7 @@ Similar to the `dm.` command, with `dmi.` you can see the closest symbol to the 
 
 Another useful command is to list the sections of a specific library. In the following example we'll list the sections of `ld-2.27.so`:
 
-```
+```console
 [0x55a7ebf09520]> dmS ld-2.27
 [Sections]
 00 0x00000000     0 0x00000000     0 ---- ld-2.27.so.

--- a/src/debugger/registers.md
+++ b/src/debugger/registers.md
@@ -4,7 +4,7 @@ The registers are part of a user area stored in the context structure used by th
 
 There are different commands to get values of registers. For the General Purpose ones use:
 
-```
+```console
 [0x4A13B8C0]> dr
 r15 = 0x00000000
 r14 = 0x00000000
@@ -33,7 +33,7 @@ rsp = 0x7fff515923c0
 
 Interaction between a plugin and the core is done by commands returning radare instructions. This is used, for example, to set flags in the core to set  values of registers.
 
-```
+```console
 [0x7f0f2dbae630]> dr*      ; Appending '*' will show radare commands
 f r15 1 0x0
 f r14 1 0x0
@@ -60,7 +60,7 @@ f rsp 1 0x7fff73557940
 
 An old copy of registers is stored all the time to keep track of the changes done during execution of a program being analyzed. This old copy can be accessed with `oregs`.
 
-```
+```console
 [0x7f1fab84c630]> dro
 r15 = 0x00000000
 r14 = 0x00000000
@@ -85,7 +85,7 @@ rsp = 0x7fff386b5080
 
 Current state of registers
 
-```
+```console
 [0x7f1fab84c630]> dr
 r15 = 0x00000000
 r14 = 0x00000000
@@ -112,21 +112,21 @@ Values stored in eax, oeax and eip have changed.
 
 To store and restore register values you can just dump the output of 'dr*' command to disk and then re-interpret it again:
 
-```
+```console
 [0x4A13B8C0]> dr* > regs.saved ; save registers
 [0x4A13B8C0]> drp regs.saved ; restore
 ```
 
 EFLAGS can be similarly altered. E.g., setting selected flags:
 
-```
+```console
 [0x4A13B8C0]> dr eflags = pst
 [0x4A13B8C0]> dr eflags = azsti
 ```
 
 You can get a string which represents latest changes of registers using `drd` command (diff registers):
 
-```
+```console
 [0x4A13B8C0]> drd
 oeax = 0x0000003b was 0x00000000 delta 59
 rip = 0x7f00e71282d0 was 0x00000000 delta -418217264
@@ -148,7 +148,7 @@ Radare2 is able to parse the gdb xml register profile and generate one in the ra
 
 Let's check how the x86-16 (real mode) register profile looks like by typing the following command:
 
-```
+```console
 $ r2 -a x86 -b 16 -qc arp --
 =PC	ip
 =SP	sp
@@ -202,7 +202,7 @@ Register profiles are usually 'static', in the sense that users won't need to mo
 
 These are the commands you must use to dump the current register profile to a file, edit it and then load it again:
 
-```
+```sh
 drp > profile.txt
 vim profile.txt
 drp profile.txt

--- a/src/debugger/remote_gdb.md
+++ b/src/debugger/remote_gdb.md
@@ -4,13 +4,13 @@ radare2 allows remote debugging over the gdb remote protocol. So you can run a
 gdbserver and connect to it with radare2 for remote debugging. The syntax for
 connecting is:
 
-```
+```console
 $ r2 -d gdb://<host>:<port>
 ```
 
 Note that the following command does the same, r2 will use the debug plugin specified by the uri if found.
 
-```
+```console
 $ r2 -D gdb gdb://<host>:<port>
 ```
 
@@ -19,14 +19,14 @@ The debug plugin can be changed at runtime using the dL or Ld commands.
 Or if the gdbserver is running in extended mode, you can attach to a process on
 the host with:
 
-```
+```console
 $ r2 -d gdb://<host>:<port>/<pid>
 ```
 
 It is also possible to start debugging after analyzing a file using the `doof` command
 which rebases the current session's data after opening gdb
 
-```
+```console
 [0x00404870]> doof gdb://<host>:<port>/<pid>
 ```
 
@@ -36,20 +36,20 @@ radare2 does not yet load symbols from gdbserver, so it needs the binary to
 be locally present to load symbols from it. In case symbols are not loaded even
 if the binary is present, you can try specifying the path with `e dbg.exe.path`:
 
-```
+```console
 $ r2 -e dbg.exe.path=<path> -d gdb://<host>:<port>
 ```
 
 If symbols are loaded at an incorrect base address, you can try specifying
 the base address too with `e bin.baddr`:
 
-```
+```console
 $ r2 -e bin.baddr=<baddr> -e dbg.exe.path=<path> -d gdb://<host>:<port>
 ```
 
 Usually the gdbserver reports the maximum packet size it supports. Otherwise, radare2 resorts to sensible defaults. But you can specify the maximum packet size with the environment variable `R2_GDB_PKTSZ`. You can also check and set the max packet size during a session with the IO system, `:`.
 
-```
+```console
 $ export R2_GDB_PKTSZ=512
 $ r2 -d gdb://<host>:<port>
 = attach <pid> <tid>
@@ -63,7 +63,7 @@ packet size: 64 bytes
 
 The gdb IO system provides useful commands which might not fit into any standard radare2 commands. You can get a list of these commands with `:?`. (Remember, `:` accesses the underlying IO plugin's `system()`).
 
-```
+```console
 [0x7ff659d9fcc0]> :?
 Usage: :cmd args
  :pid             - show targeted pid
@@ -88,7 +88,7 @@ monitor GDB client/server messages on radare2's side.
 
 radare2 also provides its own gdbserver implementation:
 
-```
+```console
 $ r2 -
 [0x00000000]> =g?
 |Usage:  =[g] [...] # gdb server
@@ -98,13 +98,13 @@ $ r2 -
 
 So you can start it as:
 
-```
+```console
 $ r2 -
 [0x00000000]> =g 8000 /bin/radare2 -
 ```
 
 And then connect to it like you would to any gdbserver. For example, with radare2:
 
-```
+```console
 $ r2 -d gdb://localhost:8000
 ```

--- a/src/debugger/remoting_capabilities.md
+++ b/src/debugger/remoting_capabilities.md
@@ -5,7 +5,7 @@ radare2 process. This is possible because everything uses radare's IO subsystem 
 
 Help for commands useful for remote access to radare:
 
-```
+```console
 [0x00405a04]> =?
 Usage:  =[:!+-=ghH] [...]   # connect with other instances of r2
 
@@ -44,25 +44,25 @@ A little example should make this clearer. A typical remote session might look l
 
 At the remote host1:
 
-```
+```console
 $ radare2 rap://:1234
 ```
 
 At the remote host2:
 
-```
+```console
 $ radare2 rap://:1234
 ```
 
 At localhost:
 
-```
+```console
 $ radare2 -
 ```
 
 Add hosts
 
-```
+```console
 [0x004048c5]> =+ rap://<host1>:1234//bin/ls
 Connected to: <host1> at port 1234
 waiting... ok
@@ -73,7 +73,7 @@ waiting... ok
 
 You can open remote files in debug mode (or using any IO plugin) specifying URI when adding hosts:
 
-```
+```console
 [0x004048c5]> =+ =+ rap://<host2>:1234/dbg:///bin/ls
 Connected to: <host2> at port 1234
 waiting... ok
@@ -83,14 +83,14 @@ waiting... ok
 
 To execute commands on host1:
 
-```
+```console
 [0x004048c5]> =0 px
 [0x004048c5]> = s 0x666
 ```
 
 To open a session with host2:
 
-```
+```console
 [0x004048c5]> ==1
 fd:6> pi 1
 ...
@@ -99,13 +99,13 @@ fd:6> q
 
 To remove hosts (and close connections):
 
-```
+```console
 [0x004048c5]> =-
 ```
 
 You can also redirect radare output to a TCP or UDP server (such as `nc -l`). First, Add the server with '=+ tcp://' or '=+ udp://', then you can redirect the output of a command to be sent to the server:
 
-```
+```console
 [0x004048c5]> =+ tcp://<host>:<port>/
 Connected to: <host> at port <port>
 5 - tcp://<host>:<port>/

--- a/src/debugger/revdebug.md
+++ b/src/debugger/revdebug.md
@@ -5,7 +5,7 @@ Radare2 has reverse debugger, that can seek the program counter backward.
 Firstly you need to save program state at the point that you want to start recording.
 The syntax for recording is:
 
-```
+```console
 [0x004028a0]> dts+
 ```
 
@@ -13,7 +13,7 @@ You can use `dts` commands for recording and managing program states.
 After recording the states, you can seek pc back and forth to any points after saved address.
 So after recording, you can try single step back:
 
-```
+```console
 [0x004028a0]> 2dso
 [0x004028a0]> dr rip
 0x004028ae
@@ -29,7 +29,7 @@ until desired point.
 
 Or you can also try continue back:
 
-```
+```console
 [0x004028a0]> db 0x004028a2
 [0x004028a0]> 10dso
 [0x004028a0]> dr rip
@@ -44,7 +44,7 @@ So once set a breakpoint, you can back to it any time.
 
 You can see current recorded program states using `dts`:
 
-```
+```console
 [0x004028a0]> dts
 session: 0   at:0x004028a0   ""
 session: 1   at:0x004028c2   ""
@@ -56,7 +56,7 @@ than entire dump.
 
 And also can add comment:
 
-```
+```console
 [0x004028c2]> dtsC 0 program start
 [0x004028c2]> dtsC 1 decryption start
 [0x004028c2]> dts
@@ -71,7 +71,7 @@ many records.
 Program records can exported to file and of course import it.
 Export/Import records to/from file:
 
-```
+```console
 [0x004028c2]> dtst records_for_test
 Session saved in records_for_test.session and dump in records_for_test.dump
 [0x004028c2]> dtsf records_for_test
@@ -82,13 +82,13 @@ session: 1, 0x4028c2 diffs: 0
 Moreover, you can do reverse debugging in ESIL mode.
 In ESIL mode, program state can be managed by `aets` commands.
 
-```
+```console
 [0x00404870]> aets+
 ```
 
 And step back by `aesb`:
 
-```
+```console
 [0x00404870]> aer rip
 0x00404870
 [0x00404870]> 5aeso

--- a/src/debugger/signals.md
+++ b/src/debugger/signals.md
@@ -2,7 +2,7 @@
 
 You can send signals to the target process, or change the behaviour of the the debugger and signal handler associated with the `dk` command.
 
-```
+```console
 [0x00000000]> dk?
 Usage: dk  Signal commands
 | dk                         list all signal handlers of child process
@@ -19,7 +19,7 @@ To change the behaviour of the r2 debugger when the target process receives a sp
 
 These are the list of signals with their associated numbers:
 
-```
+```console
 [0x00000000]> dk
 32 SIGRTMIN 30 SIGPWR 14 SIGALRM 31 SIGSYS 15 SIGTERM 16 SIGSTKFLT
 17 SIGCHLD 10 SIGUSR1 11 SIGSEGV 12 SIGUSR2 13 SIGPIPE 18 SIGCONT

--- a/src/debugger/windbg.md
+++ b/src/debugger/windbg.md
@@ -17,7 +17,7 @@ just an initial implementation which will get better in time.
 
 Enable KD over a serial port on Windows Vista and higher like this:
 
-```
+```bat
 bcdedit /debug on
 bcdedit /dbgsettings serial debugport:1 baudrate:115200
 ```
@@ -26,7 +26,7 @@ Or like this for Windows XP:
 
 * Open boot.ini and add /debug /debugport=COM1 /baudrate=115200:
 
-```
+```ini
 [boot loader]
 timeout=30
 default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
@@ -60,7 +60,7 @@ Configure the VirtualBox Machine like this:
 
 Or just spawn the VM with qemu like this:
 
-```
+```console
 $ qemu-system-x86_64 -chardev socket,id=serial0,\
      path=/tmp/winkd.pipe,nowait,server \
      -serial chardev:serial0 -hda Windows7-VM.vdi
@@ -70,7 +70,7 @@ $ qemu-system-x86_64 -chardev socket,id=serial0,\
 
 Enable KD over network (KDNet) on Windows 7 or later likes this:
 
-```
+```bat
 bcdedit /debug on
 bcdedit /dbgsettings net hostip:w.x.y.z port:n
 ```
@@ -79,7 +79,7 @@ Starting from Windows 8 there is no way to enforce debugging
 for every boot, but it is possible to always show the advanced boot options,
 which allows to enable kernel debugging:
 
-```
+```bat
 bcedit /set {globalsettings} advancedoptions true
 ```
 
@@ -91,19 +91,19 @@ Radare2 will use the `winkd` io plugin to connect to a socket file
 created by virtualbox or qemu. Also, the `winkd` debugger plugin and
 we should specify the x86-32 too. (32 and 64 bit debugging is supported)
 
-```
+```console
 $ r2 -a x86 -b 32 -D winkd winkd:///tmp/winkd.pipe
 ```
 
 On Windows you should run the following line:
 
-```
+```console
 $ radare2 -D winkd winkd://\\.\pipe\com_1
 ```
 
 ##### Network
 
-```
+```console
 $ r2 -a x86 -b 32 -d winkd://<hostip>:<port>:w.x.y.z
 ```
 
@@ -112,7 +112,7 @@ $ r2 -a x86 -b 32 -d winkd://<hostip>:<port>:w.x.y.z
 When connecting to a KD interface, r2 will send a breakin packet to interrupt
 the target and we will get stuck here:
 
-```
+```console
 [0x828997b8]> pd 20
 	;-- eip:
 	0x828997b8    cc           int3
@@ -155,25 +155,25 @@ You can use the debugging DLLs included on Windows or get the latest version fro
 
 To use the `windbg` plugin, pass the same command-line options as you would for `WinDBG` or `kd` (see Microsoft's [documentation](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/windbg-command-line-options)), quoting/escaping when necessary:
 
-```
+```console
 > r2 -d "windbg://-remote tcp:server=Server,port=Socket"
 ```
 
-```
+```console
 > r2 -d "windbg://MyProgram.exe \"my arg\""
 ```
 
-```
+```console
 > r2 -d "windbg://-k net:port=<n>,key=<MyKey>"
 ```
 
-```
+```console
 > r2 -d "windbg://-z MyDumpFile.dmp"
 ```
 
 You can then debug normally (see `d?` command) or interact with the backend shell directly with the `=!` command:
 
-```
+```console
 [0x7ffcac9fcea0]> dcu 0x0007ffc98f42190
 Continue until 0x7ffc98f42190 using 1 bpsize
 ModLoad: 00007ffc`ab6b0000 00007ffc`ab6e0000   C:\WINDOWS\System32\IMM32.DLL

--- a/src/debugger/windows_messages.md
+++ b/src/debugger/windows_messages.md
@@ -4,7 +4,7 @@ On Windows, you can use `dbW` while debugging to set a breakpoint for the messag
 
 Get a list of the current process windows with  `dW` :
 
-```
+```console
 [0x7ffe885c1164]> dW
 .----------------------------------------------------.
 | Handle      | PID   | TID    | Class Name          |
@@ -19,21 +19,21 @@ Get a list of the current process windows with  `dW` :
 
 Set the breakpoint with a message type, together with either the window class name or its handle:
 
-```
+```console
 [0x7ffe885c1164]> dbW WM_KEYDOWN Edit
 Breakpoint set.
 ```
 
 Or
 
-```
+```console
 [0x7ffe885c1164]> dbW WM_KEYDOWN 0x002c048a
 Breakpoint set.
 ```
 
 If you aren't sure which window you should put a breakpoint on, use `dWi` to identify it with your mouse:
 
-```
+```console
 [0x7ffe885c1164]> dWi
 Move cursor to the window to be identified. Ready? y
 Try to get the child? y

--- a/src/emulation/analysis.md
+++ b/src/emulation/analysis.md
@@ -10,7 +10,7 @@ still sometimes required, particularly when deobfuscating or unpacking code. To
 show the emulation process, you can set `asm.emu` variable which will show
 calculated register and memory values as comments in the disassembly:
 
-```
+```console
 [0x00001660]> e asm.emu=true
 [0x00001660]> pdf
 . (fcn) fcn.00001660 40
@@ -39,7 +39,7 @@ Apart from the basic ESIL VM setup, you can change its behavior with other optio
 
 The debugger APIs can be configured to use different backends, to communicate with a local or remote GDB server, use the native debugger, a specific virtualization or emulation engine like Unicorn or BOCHS, but there's also an ESIL backend.
 
-```
+```console
 [0x00000000]> dL
 0  ---  bf       LGPL3
 1  ---  bochs    LGPL3

--- a/src/emulation/esil.md
+++ b/src/emulation/esil.md
@@ -2,7 +2,7 @@
 
 ESIL stands for 'Evaluable Strings Intermediate Language'. It aims to describe a [Forth](https://en.wikipedia.org/wiki/Forth_%28programming_language%29)-like representation for every target CPU opcode semantics. ESIL representations can be evaluated (interpreted) in order to emulate individual instructions. Each command of an ESIL expression is separated by a comma. Its virtual machine can be described as this:
 
-```
+```c
    while ((word=haveCommand())) {
      if (word.isOperator()) {
        esilOperators[word](esil);
@@ -37,7 +37,7 @@ r2's visual mode is great to inspect the ESIL evaluations.
 
 There are 3 environment variables that are important for watching what a program does:
 
-```
+```console
 [0x00000000]> e emu.str = true
 ```
 
@@ -48,7 +48,7 @@ One problem with this is that it is a lot of information to take in at once and 
 The third important variable is `asm.esil`. This switches your disassembly to no longer show you the actual disassembled instructions, but instead now shows you corresponding ESIL expressions that describe what the instruction does.
 So if you want to take a look at how instructions are expressed in ESIL simply set "asm.esil" to true.
 
-```
+```console
 [0x00000000]> e asm.esil = true
 ```
 
@@ -58,7 +58,7 @@ In visual mode you can also toggle this by simply typing `O`.
 
 * "ae" : Evaluate ESIL expression.
 
-```
+```console
 [0x00000000]> "ae 1,1,+"
 0x2
 [0x00000000]>
@@ -66,21 +66,21 @@ In visual mode you can also toggle this by simply typing `O`.
 
 * "aes" : ESIL Step.
 
-```
+```console
 [0x00000000]> aes
 [0x00000000]>10aes
 ```
 
 * "aeso" : ESIL Step Over.
 
-```
+```console
 [0x00000000]> aeso
 [0x00000000]>10aeso
 ```
 
 * "aesu" : ESIL Step Until.
 
-```
+```console
 [0x00001000]> aesu 0x1035
 ADDR BREAK
 [0x00001019]>
@@ -88,7 +88,7 @@ ADDR BREAK
 
 * "ar" : Show/modify ESIL registry.
 
-```
+```console
 [0x00001ec7]> ar r_00 = 0x1035
 [0x00001ec7]> ar r_00
 0x00001035
@@ -215,7 +215,7 @@ zf,?{,eip,esp,=[],eax,eip,=,$r,esp,-=,}
 
 Whitespaces, newlines and other chars are ignored. So the first thing when processing a ESIL program is to remove spaces:
 
-```
+```c
 esil = r_str_replace (esil, " ", "", R_TRUE);
 ```
 
@@ -344,7 +344,7 @@ fmulp ST(1), ST(0)      =>      TODO,fmulp ST(1),ST(0)
 
 ### ESIL Disassembly Example
 
-```
+```console
 [0x1000010f8]> e asm.esil=true
 [0x1000010f8]> pd $r @ entry0
 0x1000010f8    55           8,rsp,-=,rbp,rsp,=[8]
@@ -379,7 +379,7 @@ fmulp ST(1), ST(0)      =>      TODO,fmulp ST(1),ST(0)
 
 To ease ESIL parsing we should have a way to express introspection expressions to extract the data that we want. For example, we may want to get the target address of a jump. The parser for ESIL expressions should offer an API to make it possible to extract information by analyzing the expressions easily.
 
-```
+```console
 >  ao~esil,opcode
 opcode: jmp 0x10000465a
 esil: 0x10000465a,rip,=

--- a/src/emulation/intro.md
+++ b/src/emulation/intro.md
@@ -23,7 +23,7 @@ There are many use cases for ESIL in radare2, not just bare code emulation:
 
 To view the ESIL representation of your program, use the `ao~esil` command or enable the `asm.esil` configuration variable. This will let you verify how the code is uplifted from assembly to ESIL and understand better how that works internally.
 
-```
+```console
 [0x00001660]> pdf
 . (fcn) fcn.00001660 40
 |   fcn.00001660 ();

--- a/src/first_steps/basic_debugger_session.md
+++ b/src/first_steps/basic_debugger_session.md
@@ -2,7 +2,7 @@
 
 To debug a program, start radare with the `-d` option. Note that you can attach to a running process by specifying its PID, or you can start a new program by specifying its name and parameters:
 
-```
+```console
 $ pidof mc
 32220
 $ r2 -d 32220
@@ -28,7 +28,7 @@ Be warned that certain malware or other tricky programs can actually execute cod
 
 Below is a list of most common commands used with debugger:
 
-```
+```console
 > d?            ; get help on debugger commands
 > ds 3          ; step 3 times
 > db 0x8048920  ; setup a breakpoint
@@ -47,7 +47,7 @@ That way you will neither need to remember many commands nor to keep program sta
 
 To enter visual debugger mode use `Vpp`:
 
-```
+```console
 [0xb7f0c8c0]> Vpp
 ```
 

--- a/src/first_steps/commandline_flags.md
+++ b/src/first_steps/commandline_flags.md
@@ -4,7 +4,7 @@ Radare2 can be used directly from the command line, allowing you to run commands
 
 For example, if we want to show 10 bytes from the entrypoint directly from the system shell we can use:
 
-```
+```console
 $ r2 -q -c 'p8 10 @ entry0' /bin/ls
 ```
 
@@ -14,13 +14,13 @@ Command-line flags are options you add when starting radare2. These flags let yo
 
 We can set some options at startup time with the `-e` flag like this:
 
-```
+```sh
 r2 -e scr.color=0 -e io.cache=true /bin/ls
 ```
 
 The help message, accessed by running radare2 with the -h flag, shows all available options. It's a quick reference for radare2's capabilities. By exploring this message, you can discover features you might not know about.
 
-```
+```console
 $ radare2 -h
 Usage: r2 [-ACdfjLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-c cmd]
           [-s addr] [-B baddr] [-m maddr] [-i script] [-e k=v] file|pid|-|--|=
@@ -78,54 +78,54 @@ At first sight it may seem like there are so many options and without some pract
 
 Open a file in write mode and do not parse the headers (raw mode).
 
-```bash
+```console
 $ r2 -nw file
 ```
 
 Quickly get into the r2 shell opening a 1KB malloc virtual file, handy for testing things. note that a single dash is an alias for malloc://1024
 
-```
+```console
 $ r2 -
 ```
 
 Specify which sub-binary you want to select when opening a fatbin file:
 
-```
+```console
 $ r2 -a ppc -b 32 ls.fat
 ```
 
 Run a script before entering the prompt:
 
-```
+```console
 $ r2 -i patch.r2 target.bin
 ```
 
 Execute a command and quit without entering the interactive mode:
 
-```
+```console
 $ r2 -qc ij hi.bin > imports.json
 ```
 
 Set the configuration variable:
 
-```
+```console
 $ r2 -e scr.color=0 blah.bin
 ```
 
 Spawn and start debugging a program:
 
-```
+```console
 $ r2 -d ls
 ```
 
 Attach to an already running process by its process id (PID):
 
-```
+```console
 $ r2 -d 1234
 ```
 
 Load an existing project file:
 
-```
+```console
 $ r2 -p test
 ```

--- a/src/first_steps/expressions.md
+++ b/src/first_steps/expressions.md
@@ -7,7 +7,7 @@ as well as binary and boolean ones.
 
 To evaluate mathematical expressions prepend them with command `?`:
 
-```
+```console
 [0xb7f9d810]> ?vi 0x8048000
 134512640
 [0xv7f9d810]> ?vi 0x8048000+34
@@ -45,14 +45,14 @@ Supported arithmetic operations are:
 
 For example, using the `?vi` command we the the integer (base10) value resulting it from evaluating the given math expression
 
-```
+```console
 [0x00000000]> ?vi 1+2+3
 6
 ```
 
 To use of binary OR should quote the whole command to avoid executing the `|` pipe:
 
-```
+```console
 [0x00000000]> "? 1 | 2"
 hex     0x3
 octal   03
@@ -97,14 +97,14 @@ $b    block size
 
 Some more examples:
 
-```
+```console
 [0x4A13B8C0]> ? $m + $l
 140293837812900 0x7f98b45df4a4 03771426427372244 130658.0G 8b45d000:04a4 140293837812900 10100100 140293837812900.0 -0.000000
 ```
 
 Disassembling the very next instruction after the current one
 
-```
+```console
 [0x4A13B8C0]> pd 1 @ +$l
 0x4A13B8C2   call 0x4a13c000
 ```

--- a/src/first_steps/intro.md
+++ b/src/first_steps/intro.md
@@ -14,7 +14,7 @@ The 'print' command is abbreviated as `p` and has a number of submodes — the s
 
 To be allowed to write files, specify the `-w` option to radare2 when opening a file. The `w` command can be used to write strings, hexpairs (`x` subcommand), or even assembly opcodes (`a` subcommand). Examples:
 
-```
+```console
 > w hello world         ; string
 > wx 90 90 90 90        ; hexpairs
 > wa jmp 0x8048140      ; assemble

--- a/src/first_steps/syntax.md
+++ b/src/first_steps/syntax.md
@@ -64,7 +64,7 @@ Note that the environment variables will be different depending on how we execut
 * spawning processes with ! (get some context details, like offset, file, ..)
 * r2pipe environment (`R2PIPE_IN` and `R2PIPE_OUT` with the pipe descriptors)
 
-```
+```console
 [0x00000000]> !export | grep R2_
 export R2_ARCH="arm"
 export R2_BITS="64"
@@ -83,7 +83,7 @@ export R2_XOFFSET="0x00000000"
 
 We can also find the location in memory of the RCore instance in the current process. This can be useful when injecting code inside radare2 (like when injecting r2 via r2frida or using native api calls on live runtimes without having to pass pointers or depend on RLang setups) We may learn more about this in the scripting chapter.
 
-```
+```console
 [0x00000000]> %~R2
 R2CORE=0x140018000
 [0x00000000]>
@@ -185,7 +185,7 @@ The purpose of this syntax rings some bells when you use the `*` suffix or the `
 
 For example, we can load the symbols from a binary in disk by running the following line:
 
-```
+```console
 > .!rabin2 -rs $R2_FILE
 ```
 

--- a/src/install/android.md
+++ b/src/install/android.md
@@ -20,13 +20,13 @@ Download the Termux application from the [official site](https://github.com/term
 
 First time installation of termux require updating the repo to fetch all the available packages.
 
-```
+```console
 $ pkg update && pkg upgrade -y
 ```
 
 ##### Install required packages
 
-```
+```console
 $ pkg install build-essential git python3 binutils wget pkg-config
 ```
 
@@ -34,7 +34,7 @@ build-essential contains all the required build tool like make,gcc etc.
 
 ##### Download or clone Radare2 repo
 
-```
+```console
 $ git clone https://github.com/radareorg/radare2
 ```
 
@@ -44,14 +44,14 @@ If you are limited by disk space, you can either clone the repository with a dep
 
 Building and installing Radare2 after cloning the repository is straightforward using the following commands:
 
-```
+```sh
 cd radare2
 sh sys/install.sh
 ```
 
 It will install required packages if you already didn't and start the installation.
 
-```
+```console
 ~/radare2 $ sh sys/install.sh
 /data/data/com.termux/files/home/radare2
 Termux environment detected. Installing necessary packages

--- a/src/install/build.md
+++ b/src/install/build.md
@@ -12,7 +12,7 @@ Note that there are I/O plugins that use GDB, WinDbg, or Wine as back-ends, and 
 
 To build on a system using `acr` and `GNU Make` (e.g. on _BSD systems_):
 
-```sh
+```console
 $ ./configure --prefix=/usr
 $ gmake
 $ sudo gmake install
@@ -20,7 +20,7 @@ $ sudo gmake install
 
 There is also a simple script to do this automatically:
 
-```sh
+```console
 $ sys/install.sh
 ```
 
@@ -28,7 +28,7 @@ $ sys/install.sh
 
 To build and run radare2 in your home just run the sys/user.sh script.
 
-```sh
+```console
 $ sys/user.sh
 ```
 
@@ -36,7 +36,7 @@ $ sys/user.sh
 
 You can build radare2 statically along with all other tools with the command:
 
-```sh
+```console
 $ sys/static.sh
 ```
 
@@ -44,19 +44,19 @@ $ sys/static.sh
 
 You can use meson/ninja to build (or muon/samu):
 
-```sh
+```console
 $ meson b && ninja -C b
 ```
 
 There's a helper script in sys/ to make the meson experience a little bit simpler:
 
-```sh
+```console
 $ sys/meson.py --prefix=/usr --shared --install
 ```
 
 If you want to build locally:
 
-```sh
+```console
 $ sys/meson.py --prefix=/home/$USER/r2meson --local --shared --install
 ```
 

--- a/src/install/download.md
+++ b/src/install/download.md
@@ -8,7 +8,7 @@ A new stable release is typically published every month.
 
 The radare development repository is often more stable than the 'stable' releases. To obtain the latest version:
 
-```
+```console
 $ git clone https://github.com/radareorg/radare2.git
 ```
 
@@ -16,25 +16,25 @@ This will probably take a while, so take a coffee break and continue reading thi
 
 To update your local copy of the repository, use `git pull` anywhere in the radare2 source code tree:
 
-```
+```console
 $ git pull
 ```
 
 If you have local modifications of the source, you can revert them (and lose them!) with:
 
-```
+```console
 $ git reset --hard HEAD
 ```
 
 Or send us a patch:
 
-```
+```console
 $ git diff > radare-foo.patch
 ```
 
 The most common way to get r2 updated and installed system wide is by using:
 
-```
+```console
 $ sys/install.sh
 ```
 
@@ -68,7 +68,7 @@ Cleaning up the source tree is important to avoid problems like linking to old o
 
 The following commands may help you to get your git clone up to date:
 
-```
+```console
 $ git clean -xdf
 $ git reset --hard origin/master
 $ git pull
@@ -76,7 +76,7 @@ $ git pull
 
 If you want to remove previous installations from your system, you must run the following commands:
 
-```
+```console
 $ ./configure --prefix=/usr/local
 $ make purge
 ```

--- a/src/install/windows.md
+++ b/src/install/windows.md
@@ -47,7 +47,7 @@ When python is installed ensure to set the bin directory in your PATH, so you ca
 
 Now you are ready to install meson and ninja, the radare2 build tools with pip:
 
-```
+```sh
 pip install ninja
 pip install meson
 ```
@@ -73,7 +73,7 @@ Check the following options during the Wizard steps.
 
 Follow these steps to clone the Radare2 git repository.
 
-```
+```sh
 git clone https://github.com/radareorg/radare2
 ```
 

--- a/src/intro/overview.md
+++ b/src/intro/overview.md
@@ -29,7 +29,7 @@ A minimalistic mathematical expression evaluator for the shell that is useful fo
 
 Examples
 
-```
+```console
 $ rax2 1337
 0x539
 
@@ -81,7 +81,7 @@ The command-line assembler and disassembler. It supports a wide range of archite
 
 For example assembling and disassembling a nop for java:
 
-```
+```console
 $ rasm2 -a java 'nop'
 00
 
@@ -110,14 +110,14 @@ Versatile command-line hashing tool that is part of the radare2 framework. It's 
 
 Here are few usage examples:
 
-```
+```console
 $ rahash2 file
 file: 0x00000000-0x00000007 sha256: 887cfbd0d44aaff69f7bdbedebd282ec96191cce9d7fa7336298a18efc3c7a5a
 ```
 
 Algorithms can be selected by specifying them separated with the `-a` flag.
 
-```
+```console
 $ rahash2 -a md5 file
 file: 0x00000000-0x00000007 md5: d1833805515fc34b46c2b9de553f599d
 ```
@@ -160,7 +160,7 @@ This feature is conceptually based on shellforge4, but only linux/osx x86-32/64 
 
 It can also compile a specific low level domain specific language and generate tiny binaries without the need of any system compiler or toolchain as exemplified below:
 
-```
+```console
 $ cat hi.r
 /* hello world in r_egg */
 write@syscall(4); //x64 write@syscall(1);

--- a/src/intro/ui.md
+++ b/src/intro/ui.md
@@ -18,6 +18,6 @@ The current main radare2 GUI is Iaito. It is written in C++ using Qt and was ori
 
 In addition, r2 includes an embedded webserver with a basic HTML/JS interface. Add `-c=H` to your command-line flags to automatically start the webserver and open it in your browser.
 
-```
+```console
 $ r2 -c=H /bin/ls
 ```

--- a/src/plugins/dev.md
+++ b/src/plugins/dev.md
@@ -129,7 +129,7 @@ struct r_lib_struct_t radare_plugin = {
 
 To build and install this plugin just type this:
 
-```
+```console
 $ make
 $ sudo make install
 ```

--- a/src/plugins/intro.md
+++ b/src/plugins/intro.md
@@ -19,7 +19,7 @@ All of them can be installed via r2pm.
 
 See [r2skel](r2skel.md)
 
-```
+```console
 $ ls libr/*/p | grep : | awk -F / '{ print $2 }'
 anal      # analysis plugins
 asm       # assembler/disassembler plugins

--- a/src/plugins/ioplugins.md
+++ b/src/plugins/ioplugins.md
@@ -8,21 +8,21 @@ So, when radare reads a block of bytes, it is the task of an IO plugin to get th
 
 * Debugging URIs
 
-```
+```console
 $ r2 dbg:///bin/ls
 $ r2 pid://1927
 ```
 
 * Remote sessions
 
-```
+```console
 $ r2 rap://:1234
 $ r2 rap://<host>:1234//bin/ls
 ```
 
 * Virtual buffers
 
-```
+```console
 $ r2 malloc://512
 shortcut for
 $ r2 -
@@ -30,7 +30,7 @@ $ r2 -
 
 You can get a list of the radare IO plugins by typing `radare2 -L`:
 
-```
+```console
 $ r2 -L
 rw_  ar       Open ar/lib files [ar|lib]://[file//path] (LGPL3)
 rw_  bfdbg    BrainFuck Debugger (bfdbg://path/to/file) (LGPL3)

--- a/src/plugins/python.md
+++ b/src/plugins/python.md
@@ -139,8 +139,8 @@ For this you need to do this:
 
     You can combine everything in one file and load it using `-i` option:
 
-    ```
-    r2 -I mycpu.py some_file.bin
+    ```console
+    $ r2 -I mycpu.py some_file.bin
     ```
 
 Or you can load it from the r2 shell: `#!python mycpu.py`

--- a/src/plugins/r2pm.md
+++ b/src/plugins/r2pm.md
@@ -4,7 +4,7 @@ As explained in more detail in the [package manager](../tools/r2pm/intro.md) cha
 
 All the current packages are located in the [radare2-pm](https://github.com/radareorg/radare2-pm) repository, check some of the already existing ones for inspiration as you will see how easy it's format is:
 
-```
+```sh
 R2PM_BEGIN
 
 R2PM_GIT "https://github.com/user/mycpu"
@@ -26,7 +26,7 @@ R2PM_END
 
 Add your package in the `/db` directory of radare2-pm repository and send a pull request when it's ready to be shared.
 
-```
+```console
 $ r2pm -H R2PM_DBDIR
 /Users/pancake/.local/share/radare2/r2pm/git/radare2-pm/db
 $

--- a/src/plugins/r2skel.md
+++ b/src/plugins/r2skel.md
@@ -11,7 +11,7 @@ The repository have different type of plugins and scripts organized by language 
 
 ## Installation
 
-```
+```console
 $ r2pm -ci r2skel
 ```
 
@@ -19,7 +19,7 @@ $ r2pm -ci r2skel
 
 If the r2pm bindir is not in your PATH you can spawn the tool with `r2pm -r`:
 
-```
+```console
 $ r2pm -r r2skel
 r2skel [-lL] | [template] [new-directory]
 Options:
@@ -53,7 +53,7 @@ $
 
 Now you are ready to create your first example:
 
-```
+```console
 $ r2pm -r r2skel r2-plugin-core-js coreplug
 $ cd coreplug
 $ make

--- a/src/plugins/testing.md
+++ b/src/plugins/testing.md
@@ -2,14 +2,14 @@
 
 This plugin is used by rasm2 and r2. You can verify that the plugin is properly loaded with this command:
 
-```bash
+```console
 $ rasm2 -L | grep mycpu
 _d  mycpu        My CPU disassembler  (LGPL3)
 ```
 
 Let's open an empty file using the 'mycpu' arch and write some random code there.
 
-```
+```console
 $ r2 -
  -- I endians swap
 [0x00000000]> e asm.arch=mycpu
@@ -29,6 +29,6 @@ $ r2 -
 
 Yay! it works.. and the mandatory oneliner too!
 
-```bash
+```console
 $ r2 -nqamycpu -cwoR -cpd' 10' -
 ```

--- a/src/plugins/troubles.md
+++ b/src/plugins/troubles.md
@@ -4,7 +4,7 @@ It is common to have an issues when you write a plugin, especially if you do thi
 
 This is why debugging them is very important. The first step for debugging is to set an environment variable when running radare2 instance:
 
-```sh
+```console
 $ R2_DEBUG=yes r2 /bin/ls
 Loading /usr/local/lib/radare2/2.2.0-git//bin_xtr_dyldcache.so
 Cannot find symbol 'radare_plugin' in library '/usr/local/lib/radare2/2.2.0-git//bin_xtr_dyldcache.so'

--- a/src/r2frida/first_steps.md
+++ b/src/r2frida/first_steps.md
@@ -2,13 +2,13 @@
 
 If there's nothing after the peekaboo (`://`) you will get introduced into the visual uri maker which let's you select the target device, communication channel, and application/process to attach or spawn to start tracing from it.
 
-```bash
+```console
 $ r2 frida://
 ```
 
 You can invoke the help menu via the following command:
 
-```
+```console
 $ r2 'frida://?'
 r2 frida://[action]/[link]/[device]/[target]
 * action = list | apps | attach | spawn | launch
@@ -50,7 +50,7 @@ ERROR: Cannot open 'frida://?'
 
 The `:i` commands are useful to check some basic information about the runtime:
 
-```
+```console
 [0x100610000]> :i
 arch                arm
 bits                64
@@ -76,7 +76,7 @@ cwd                 /private/var/root
 
 Here we can use `:is` to enumerate the symbols present in the process.
 
-```
+```console
 [0x100610000]> :is
 0x10060c000 s _mh_execute_header
 0x100610000 s main
@@ -86,7 +86,7 @@ Here we can use `:is` to enumerate the symbols present in the process.
 
 We can also enumerate imports using `:ii`:
 
-```
+```console
 [0x55d13c11061c]> :ii
 0x7fa7d2170a4b f r_sys_getenv /home/hex/Tools/radare2/libr/util/libr_util.so
 0x7fa7d1fd61e0 f read /usr/lib/x86_64-linux-gnu/libc-2.31.so
@@ -95,7 +95,7 @@ We can also enumerate imports using `:ii`:
 
 The same goes for exports using `:iE`:
 
-```
+```console
 [0x100610000]> :iE
 0x10060c000 v _mh_execute_header
 0x100610000 f main
@@ -105,7 +105,7 @@ The same goes for exports using `:iE`:
 
 To view the libraries in memory, we can use `:il`, and we'll see some basic information such as their base address:
 
-```
+```console
 [0x100610000]> :il
 0x000000010060c000 0x0000000100614000 arm_hello_ios
 0x0000000101154000 0x00000001013fc000 substitute-loader.dylib
@@ -117,7 +117,7 @@ To view the libraries in memory, we can use `:il`, and we'll see some basic info
 
 We can get virtual memory maps using `:dm`:
 
-```
+```console
 [0x1021d8058]> :dm
 0x00000001021d4000 - 0x00000001021d8000 r-x /private/var/root/arm_hello_ios
 0x00000001021d8000 - 0x00000001021dc000 r-x /private/var/root/arm_hello_ios
@@ -130,7 +130,7 @@ We can get virtual memory maps using `:dm`:
 
 And we can get the full ranges using `:dmm`:
 
-```
+```console
 [0x1021d8058]> :dmm
 0x00000001021d4000 - 0x00000001021e4000 r-x /private/var/root/arm_hello_ios
 0x00000001021e4000 - 0x0000000102328000 rwx /usr/lib/libsubstrate.dylib
@@ -148,7 +148,7 @@ iOS and macOS apps are usually made or containing some objc metadata that is imp
 
 We can list the ObjC classes in memory using the `:icl` command:
 
-```
+```console
 [0x00000000]> :icl
 Obfuscator
 Challenge3

--- a/src/r2frida/intro.md
+++ b/src/r2frida/intro.md
@@ -17,13 +17,13 @@ Some of the most relevant features include:
 
 Install r2frida via radare2 package manager:
 
-```sh
+```console
 $ r2pm -ci r2frida
 ```
 
 Now you should be able to test if the system session works by running the following command:
 
-```sh
+```console
 $ r2 frida://0
 ```
 

--- a/src/refcard/intro.md
+++ b/src/refcard/intro.md
@@ -164,8 +164,8 @@ This feature has broken and not been resolved at the time of writing these words
 
 To save your analysis for now, write your own script which records the function name, variable name, etc. for example:
 
-```sh
-vim sample_A.r2
+```console
+$ vim sample_A.r2
 
 e scr.utf8 = false
 s 0x000403ce0

--- a/src/scripting/intro.md
+++ b/src/scripting/intro.md
@@ -14,7 +14,7 @@ There's also rlang, which lets you use radare2's inner workings from different p
 
 As mentioned before many commands can be executed in sequence by using `;` the semicolon operator.
 
-```
+```console
 [0x00404800]> pd 1 ; ao 1
  0x00404800  b827e66100   mov eax, 0x61e627  ; "tab"
 address: 0x404800
@@ -72,26 +72,26 @@ family: cpu
 And of course it's possible to redirect the output of an r2 command into a file, using the `>` and `>>`
 commands
 
-```
+```console
 [0x00404800]> px 10 @ `ao~ptr[1]` > example.txt
 [0x00404800]> px 10 @ `ao~ptr[1]` >> example.txt
 ```
 
 Radare2 also provides quite a few Unix type file processing commands like head, tail, cat, grep and many more. One such command is [Uniq](https://en.wikipedia.org/wiki/Uniq), which can be used to filter a file to display only non-duplicate content. So to make a new file with only unique strings, you can do:
 
-```
+```console
 [0x00404800]> uniq file > uniq_file
 ```
 
 Other than stdout, you can specify other file descriptors to be redirected like in the posix shell:
 
-```
+```console
 [0x00404800]> aaa 2> /dev/null
 ```
 
 The [head](https://en.wikipedia.org/wiki/Head_%28Unix%29) command can be used to see the first N number of lines in the file, similarly [tail](https://en.wikipedia.org/wiki/Tail_(Unix)) command allows the last N number of lines to be seen.
 
-```
+```console
 [0x00404800]> head 3 foodtypes.txt
 Proteins
 Fats
@@ -103,7 +103,7 @@ Water
 
 Similarly, sorting the content is also possible with the [sort](https://en.wikipedia.org/wiki/Sort_%28Unix%29) command. A typical example could be:
 
-```
+```console
 [0x00404800]> cat foods.txt
 Lentils
 Avocado

--- a/src/scripting/loops.md
+++ b/src/scripting/loops.md
@@ -11,7 +11,7 @@ We can loop over flags:
 
 For example, we want to see function information with `afi` command:
 
-```
+```console
 [0x004047d6]> afi
 #
 offset: 0x004047d0
@@ -38,7 +38,7 @@ diff: type: new
 
 Now let's say, for example, that we'd like see a particular field from this output for all functions found by analysis. We can do that with a loop over all function flags (whose names begin with `fcn.`):
 
-```
+```console
 [0x004047d6]> fs functions
 [0x004047d6]> afi @@ fcn.* ~name
 ```
@@ -47,7 +47,7 @@ This command will extract the `name` field from the `afi` output of every flag w
 matching the regexp `fcn.*`.
 There are also a predefined loop called `@@f`, which runs your command on every functions found by r2:
 
-```
+```console
 [0x004047d6]> afi @@f ~name
 ```  
 
@@ -59,7 +59,7 @@ We can also loop over a list of offsets, using the following syntax:
 
 For example, say we want to see the opcode information for 2 offsets: the current one, and at current + 2:
 
-```
+```console
 [0x004047d6]> ao @@=$$ $$+2
 address: 0x4047d6
 opcode: mov rdx, rsp
@@ -93,7 +93,7 @@ that `$$+2` is evaluated before looping, so we can use the simple arithmetic exp
 A third way to loop is by having the offsets be loaded from a file. This file should contain
 one offset per line.
 
-```
+```console
 [0x004047d0]> ?v $$ > offsets.txt
 [0x004047d0]> ?v $$+2 >> offsets.txt
 [0x004047d0]> !cat offsets.txt
@@ -106,7 +106,7 @@ mov r9, rdx
 
 radare2 also offers various `foreach` constructs for looping. One of the most useful is for looping through all the instructions of a function:
 
-```
+```console
 [0x004047d0]> pdf
 / (fcn) entry0 42
 |; UNKNOWN XREF from 0x00400018 (unk)
@@ -162,14 +162,14 @@ The last kind of looping lets you loop through predefined iterator types:
 
 This is done using the `@@@` command. The previous example of listing information about functions can also be done using the `@@@` command:
 
-```
+```console
 [0x004047d6]> afi @@@ functions ~name
 ```
 
 This will extract `name` field from `afi` output and will output a huge list of
 function names. We can choose only the second column, to remove the redundant `name:` on every line:
 
-```
+```console
 [0x004047d6]> afi @@@ functions ~name[1]
 ```
 

--- a/src/scripting/macros.md
+++ b/src/scripting/macros.md
@@ -3,14 +3,14 @@
 Apart from simple sequencing and looping, radare2 allows to write
 simple macros, using this construction:
 
-```
+```console
 [0x00404800]> (qwe; pd 4; ao)
 ```
 
 This will define a macro called 'qwe' which runs sequentially first 'pd 4' then 'ao'.
 Calling the macro using syntax `.(macro)` is simple:
 
-```
+```console
 [0x00404800]> (qwe; pd 4; ao)
 [0x00404800]> .(qwe)
 0x00404800  mov eax, 0x61e627      ; "tab"
@@ -34,14 +34,14 @@ family: cpu
 
 To list available macroses simply call `(*`:
 
-```
+```console
 [0x00404800]> (*
 (qwe ; pd 4; ao)
 ```
 
 And if want to remove some macro, just add '-' before the name:
 
-```
+```console
 [0x00404800]> (-qwe)
 Macro 'qwe' removed.
 [0x00404800]>
@@ -50,7 +50,7 @@ Macro 'qwe' removed.
 Moreover, it's possible to create a macro that takes arguments, which comes in handy in some
 simple scripting situations. To create a macro that takes arguments you simply add them to macro definition.
 
-```
+```console
 [0x00404800]
 [0x004047d0]> (foo x y; pd $0; s +$1)
 [0x004047d0]> .(foo 5 6)
@@ -102,19 +102,19 @@ Usage: $alias[=cmd] [args...]  Alias commands and data (See ?$? for help on $var
 
 The general usage of the feature is: `$alias=cmd`
 
-```
+```console
 [0x00404800]> $disas=pdf
 ```
 
 The above command will create an alias `disas` for `pdf`. The following command prints the disassembly of the main function.
 
-```
+```console
 [0x00404800]> $disas @ main
 ```
 
 Apart from commands, you can also alias a text to be printed, when called.
 
-```
+```console
 [0x00404800]> $my_alias=$test input
 [0x00404800]> $my_alias
 test input
@@ -122,7 +122,7 @@ test input
 
 To undefine alias, use `$alias=`:
 
-```
+```console
 [0x00404800]> $pmore='b 300;px'
 [0x00404800]> $
 $pmore
@@ -133,14 +133,14 @@ $pmore
 
 A single `$` in the above will list all defined aliases. It's also possible check the aliased command of an alias:
 
-```
+```console
 [0x00404800]> $pmore?
 b 200; px
 ```
 
 Can we create an alias contains alias ? The answer is yes:
 
-```
+```console
 [0x00404800]> $pStart='s 0x0;$pmore'
 [0x00404800]> $pStart
 - offset -   0 1  2 3  4 5  6 7  8 9  A B  C D  E F  0123456789ABCDEF
@@ -164,7 +164,7 @@ Can we create an alias contains alias ? The answer is yes:
 
 If a file accessed from the repl starts with the dollar sign it will be treated as a virtual one that lives in memory only for the current session of radare2. They are handy when you don't want to depend on the filesystem to create or read files. For example in webassembly environments or other sandboxed executions.
 
-```
+```console
 [0x00000000]> echo hello > $world
 [0x00000000]> cat $world
 hello
@@ -182,7 +182,7 @@ hello
 
 This is a short syntax for accessing and modifying flags, use them as numeric variables.
 
-```
+```console
 [0x00000000]> $foo:=4
 [0x00000000]> s foo
 [0x00000004]> $foo+=4

--- a/src/scripting/r2js.md
+++ b/src/scripting/r2js.md
@@ -19,13 +19,13 @@ The **rlang** plugin will be selected depending on the file extension. In this c
 
 For example:
 
-```sh
+```console
 $ r2 -i foo.r2.js /bin/ls
 ```
 
 If you want to go back to the shell after running the script use the `-q` flag:
 
-```sh
+```console
 $ r2 -qi foo.r2.js /bin/ls
 ```
 
@@ -33,7 +33,7 @@ $ r2 -qi foo.r2.js /bin/ls
 
 To enter the `r2js` repl you can use the `-j` command or flag.
 
-```sh
+```console
 0$ r2 -j
 QuickJS - Type "\h" for help
 [r2js]>
@@ -41,7 +41,7 @@ QuickJS - Type "\h" for help
 
 Same command/flag works in the r2 shell too:
 
-```sh
+```console
 [0x00000000]> -j
 QuickJS - Type "\h" for help
 [r2js]>
@@ -76,7 +76,7 @@ Radare2 supports the same esm-blob file format used by Frida, and if you don't w
 
 For example:
 
-```sh
+```console
 $ r2frida-compile -o foo.r2.js foo.ts
 $ r2 -qi foo.r2.js -
 ```

--- a/src/scripting/r2pipe.md
+++ b/src/scripting/r2pipe.md
@@ -30,7 +30,7 @@ Here there are some examples about scripting with r2pipe in different languages
 
 ### Python
 
-```
+```console
 $ pip install r2pipe
 ```
 
@@ -47,7 +47,7 @@ print(r2.cmdj("aflj"))  # evaluates JSONs and returns an object
 
 Use this command to install the r2pipe bindings
 
-```
+```console
 $ npm install r2pipe
 ```
 
@@ -74,7 +74,7 @@ Checkout the GIT repository for more examples and details.
 
 ### Go
 
-```
+```console
 $ r2pm -i r2pipe-go
 ```
 
@@ -106,7 +106,7 @@ func main() {
 
 ### Rust
 
-```
+```console
 $ cat Cargo.toml
 ...
 [dependencies]
@@ -129,7 +129,7 @@ fn main() {
 
 ### Ruby
 
-```
+```console
 $ gem install r2pipe
 ```
 

--- a/src/scripting/r2pipe2.md
+++ b/src/scripting/r2pipe2.md
@@ -25,7 +25,7 @@ The { object takes the mandatory "cmd" parameter, but can also handle two more f
 
 Let's check the help:
 
-```
+```console
 [0x00000000]> {?
 Usage: {"cmd":"...","json":false,"trim":true} # `cmd` is required
 [0x00000000]>
@@ -33,7 +33,7 @@ Usage: {"cmd":"...","json":false,"trim":true} # `cmd` is required
 
 For example:
 
-```
+```console
 [0x00000000]> '{"cmd":"?e hello"}
 {"res":"hello\n","error":false,"value":256,"code":0,"code":0}
 [0x00000000]>

--- a/src/search/automation.md
+++ b/src/search/automation.md
@@ -3,7 +3,7 @@
 The `cmd.hit` configuration variable is used to define a radare2 command to be executed when a matching entry is found by the search engine. If you want to run several commands, separate them with `;`. Alternatively, you can arrange them in a separate script, and then invoke it as a whole with `. script-file-name` command.
 For example:
 
-```
+```console
 [0x00404888]> e cmd.hit = p8 8
 [0x00404888]> / lib
 Searching 3 bytes from 0x00400000 to 0x0041ae08: 6c 69 62

--- a/src/search/backward_search.md
+++ b/src/search/backward_search.md
@@ -2,7 +2,7 @@
 
 Sometimes you want to find a keyword backwards. This is, before the current offset, to do this you can seek back and search forward by adding some search.from/to restrictions, or use the `/b` command.
 
-```
+```console
 [0x100001200]> / nop
 0x100004b15 hit0_0 .STUWabcdefghiklmnopqrstuvwxbin/ls.
 0x100004f50 hit0_1 .STUWabcdefghiklmnopqrstuwx1] [file .
@@ -15,7 +15,7 @@ Sometimes you want to find a keyword backwards. This is, before the current offs
 
 Note that `/b` is doing the same as `/`, but backward, so what if we want to use `/x` backward? We can use `/bx`, and the same goes for other search subcommands:
 
-```
+```console
 [0x100001200]> /x 90
 0x100001a23 hit1_0 90
 0x10000248f hit1_1 90

--- a/src/search/basic_searches.md
+++ b/src/search/basic_searches.md
@@ -2,7 +2,7 @@
 
 A basic search for a plain text string in a file would be something like:
 
-```
+```console
 $ r2 -q -c "/ lib" /bin/ls
 Searching 3 bytes from 0x00400000 to 0x0041ae08: 6c 69 62 
 hits: 9
@@ -19,7 +19,7 @@ hits: 9
 
 As can be seen from the output above, radare2 generates a "hit" flag for every entry found. You can then use the `ps` command to see the strings stored at the offsets marked by the flags in this group, and they will have names of the form `hit0_<index>`:
 
-```
+```console
 [0x00404888]> / ls
 ...
 [0x00404888]> ps @ hit0_0
@@ -28,14 +28,14 @@ lseek
 
 You can search for wide-char strings (e.g., unicode letters) using the `/w` command:
 
-```
+```console
 [0x00000000]> /w Hello
 0 results found.
 ```
 
 To perform a case-insensitive search for strings use `/i`:
 
-```
+```console
 [0x0040488f]> /i Stallman
 Searching 8 bytes from 0x00400238 to 0x0040488f: 53 74 61 6c 6c 6d 61 6e
 [# ]hits: 004138 < 0x0040488f  hits = 0
@@ -43,19 +43,19 @@ Searching 8 bytes from 0x00400238 to 0x0040488f: 53 74 61 6c 6c 6d 61 6e
 
 It is possible to specify hexadecimal escape sequences in the search string by prepending them with `\x`:
 
-```
+```console
 [0x00000000]> / \x7FELF
 ```
 
 if, instead, you are searching for a string of hexadecimal values, you're probably better of using the `/x` command:
 
-```
+```console
 [0x00000000]> /x 7F454C46
 ```
 
 If you want to mask some nibble during the search you can use the symbol **.** to allow any nibble value to match:
 
-```
+```console
 [0x00407354]> /x 80..80
 0x0040d4b6 hit3_0 800080
 0x0040d4c8 hit3_1 808080
@@ -64,7 +64,7 @@ If you want to mask some nibble during the search you can use the symbol **.** t
 
 You may not know some bit values of your hexadecimal pattern. Thus you may use a bit mask on your pattern. Each bit set to one in the mask indicates to search the bit value in the pattern. A bit set to zero in the mask indicates that the value of a matching value can be 0 or 1:
 
-```
+```console
 [0x00407354]> /x 808080:ff80ff
 0x0040d4c8 hit4_0 808080
 0x0040d7b0 hit4_1 808080
@@ -75,7 +75,7 @@ You can notice that the command `/x 808080:ff00ff` is equivalent to the command 
 
 Once the search is done, the results are stored in the `searches` flag space.
 
-```
+```console
 [0x00000000]> fs
 0    0 . strings
 1    0 . symbols
@@ -94,6 +94,6 @@ To remove "hit" flags after you do not need them anymore, use the `f- hit*` comm
 
 Often, during long search sessions, you will need to launch the latest search more than once. You can use the `//` command to repeat the last search.
 
-```
+```console
 [0x00000f2a]> //     ; repeat last search
 ```

--- a/src/search/intro.md
+++ b/src/search/intro.md
@@ -4,7 +4,7 @@ The radare2 search engine is based on work done by esteve, plus multiple feature
 
 Searching is accessed with `/` command.
 
-```
+```console
 [0x00000000]> /?
 |Usage: /[!bf] [arg]Search stuff (see 'e??search' for options)
 |Use io.va for searching in non virtual addressing spaces
@@ -57,7 +57,7 @@ Note that '/\*' is not a command - it starts a multiline comment. Type '\*/' to 
 
 Options are controlled by the `search.` variables.
 
-```
+```console
 [0x00000000]> e??search
         search.align: only catch aligned search hits
         search.chunk: chunk size for /+ (default size is asm.bits/8
@@ -82,7 +82,7 @@ variable first. Note the difference between `map` and `maps` - `map` will only
 search the map that you are currently in, while `maps` will search all memory
 maps, with options to narrow the search by permissions.
 
-```
+```console
 [0x00000000]> e search.in=?
 raw
 block

--- a/src/search/pattern_search.md
+++ b/src/search/pattern_search.md
@@ -3,7 +3,7 @@
 The `/p` command allows you to apply repeated pattern searches on IO backend storage. It is possible to identify repeated byte sequences without explicitly specifying them. The only command's parameter sets minimum detectable pattern length.
 Here is an example:
 
-```
+```console
 [0x00000000]> /p 10
 ```
 
@@ -11,7 +11,7 @@ This command output will show different patterns found and how many times each o
 
 It is possible to search patterns with a known difference between consecutive bytes with `/d` command. For example, the command to search all the patterns with the first and second bytes having the first bit which differs and the second and third bytes with the second bit which differs is:
 
-```
+```console
 [0x00000000]> /d 0102
 Searching 2 bytes in [0x0-0x400]
 hits: 2

--- a/src/search/search_in_assembly.md
+++ b/src/search/search_in_assembly.md
@@ -4,7 +4,7 @@ If you want to search for a certain assembler opcodes, you can use `/a` commands
 
 The command `/ad/ jmp [esp]` searches for the specified category of assembly mnemonic:
 
-```
+```console
 [0x00404888]> /ad/ jmp qword [rdx]
 f hit_0 @ 0x0040e50d   # 2: jmp qword [rdx]
 f hit_1 @ 0x00418dbb   # 2: jmp qword [rdx]
@@ -17,7 +17,7 @@ f hit_6 @ 0x00419c43   # 3: jmp qword [rdx]
 
 The command `/a jmp eax` assembles a string to machine code, and then searches for the resulting bytes:
 
-```
+```console
 [0x00404888]> /a jmp eax
 hits: 1
 0x004048e7 hit3_0 ffe00f1f8000000000b8

--- a/src/search/searching_crypto.md
+++ b/src/search/searching_crypto.md
@@ -4,8 +4,8 @@
 
 radare2 is capable of finding **expanded** keys with `/ca` command for AES and SM4 block ciphers. It searches from current seek position up to the `search.distance` limit, or until end of file is reached. You can interrupt current search by pressing `Ctrl-C`. For example, to look for AES keys in a memory dump:
 
-```
-0x00000000]> /ca aes
+```console
+[0x00000000]> /ca aes
 Searching 40 bytes in [0x0-0x1ab]
 hits: 1
 0x000000fb hit0_0 6920e299a5202a6d656e636869746f2a
@@ -17,7 +17,7 @@ For AES, the output length gives you the size of the AES key used: 128, 192 or 2
 
 `/cr` command implements the search of private keys (RSA and ECC). `/cd` command implements a similar feature to search certificates.
 
-```
+```console
 [0x00000000]> /cr
 Searching 11 bytes in [0x0-0x15a]
 hits: 2
@@ -30,7 +30,7 @@ hits: 2
 
 There is the possibility to delimit entropy sections for later use with `\s` command:
 
-```
+```console
 [0x00000000]> b
 0x100
 [0x00000000]> b 4096
@@ -59,7 +59,7 @@ The blocksize is increased to 4096 bytes from the default 100 bytes so that the 
 
 Sometimes it is useful to search if some data blocks in a binary match a given digest. The command `/h` implement such feature. For example running the following command:
 
-```
+```console
 [0x00000000]> /h sha256 83264abaf298b9238ca63cb2fd9ff0f41a7a1520ee2a17c56df459fc806de1d6 512
 INFO: Searching sha256 for 512 byte length
 INFO: Search in range 0x00000000 and 0x00000284

--- a/src/signatures/zignatures.md
+++ b/src/signatures/zignatures.md
@@ -3,7 +3,7 @@
 Radare2 has its own format of the signatures, allowing to both load/apply and
 create them on the fly. They are available under the `z` command namespace:
 
-```
+```console
 [0x00000000]> z?
 Usage: z[*j-aof/cs] [args]   # Manage zignatures
 | z            show zignatures
@@ -30,8 +30,8 @@ from the compressed SDB file using `zoz` command.
 
 To create signature you need to make function first, then you can create it from the function:
 
-```
-r2 /bin/ls
+```console
+$ r2 /bin/ls
 [0x000051c0]> aaa # this creates functions, including 'entry0'
 [0x000051c0]> zaf entry0 entry
 [0x000051c0]> z
@@ -45,7 +45,7 @@ entry:
 As you can see it made a new signature with a name `entry` from a function `entry0`.
 You can show it in JSON format too, which can be useful for scripting:
 
-```
+```console
 [0x000051c0]> zj~{}
 [
   {
@@ -71,8 +71,8 @@ If you want, instead, to save all created signatures, you need to save it into t
 
 Then we can apply them. Lets open a file again:
 
-```
-r2 /bin/ls
+```console
+$ r2 /bin/ls
  -- Log On. Hack In. Go Anywhere. Get Everything.
 [0x000051c0]> zo myentry
 [0x000051c0]> z
@@ -86,7 +86,7 @@ entry:
 This means that the signatures were successfully loaded from the file `myentry` and now we can
 search matching functions:
 
-```
+```console
 [0x000051c0]> z.
 [+] searching 0x000051c0 - 0x000052c0
 [+] searching function metrics
@@ -98,7 +98,7 @@ Note that `z.` command just checks the signatures against the current address.
 To search signatures across the all file we need to do a bit different thing.
 There is an important moment though, if we just run it "as is" - it wont find anything:
 
-```
+```console
 [0x000051c0]> z/
 [+] searching 0x0021dfd0 - 0x002203e8
 [+] searching function metrics
@@ -108,7 +108,7 @@ hits: 0
 
 Note the searching address - this is because we need to [adjust the searching](../search/configurating_the_search.md) range first:
 
-```
+```console
 [0x000051c0]> e search.in=io.section
 [0x000051c0]> z/
 [+] searching 0x000038b0 - 0x00015898
@@ -121,7 +121,7 @@ We are setting the search mode to `io.section` (it was `file` by default) to sea
 section (assuming we are currently in the `.text` section of course).
 Now we can check, what radare2 found for us:
 
-```
+```console
 [0x000051c0]> pd 5
 ;-- entry0:
 ;-- sign.bytes.entry_0:
@@ -138,7 +138,7 @@ Here we can see the comment of `entry0`, which is taken from the ELF parsing, bu
 
 Signatures configuration stored in the `zign.` config vars' namespace:
 
-```
+```console
 [0x000051c0]> e? zign.
        zign.autoload: Autoload all zignatures located in ~/.local/share/radare2/zigns
           zign.bytes: Use bytes patterns for matching
@@ -166,7 +166,7 @@ your signature is not for the correct function version. In these situations the
 `zb` commands can still help point you in the right direction by listing near
 matches.
 
-```
+```console
 [0x000040a0]> zb?
 Usage: zb[r?] [args]  # search for closest matching signatures
 | zb [n]           find n closest matching zignatures to function at current offset
@@ -176,7 +176,7 @@ Usage: zb[r?] [args]  # search for closest matching signatures
 The `zb` (zign best) command will show the top 5 closest signatures to a
 function. Each will contain a score between 1.0 and 0.0.
 
-```
+```console
 [0x0041e390]> s sym.fclose
 [0x0040fc10]> zb
 0.96032  0.92400 B  0.99664 G   sym.fclose
@@ -196,7 +196,7 @@ The `zbr` (zign best reverse) accepts a zignature name and attempts to find the
 closet matching functions. Use an analysis command, like `aa` to find functions
 first.
 
-```
+```console
 [0x00401b20]> aa
 [x] Analyze all flags starting with sym. and entry0 (aa)
 [0x00401b20]> zo ./libc.sdb

--- a/src/tools/r2pm/intro.md
+++ b/src/tools/r2pm/intro.md
@@ -11,7 +11,7 @@ The [radare2-extras](https://github.com/radareorg/radare2-extras) repository con
 
 ### Package Database
 
-```
+```console
 $ r2pm -U
 $R2PM_DBDIR: No such file or directory.
 Run 'r2pm init' to initialize the package repository
@@ -29,8 +29,8 @@ r2pm database initialized. Use 'r2pm -U' to update later today
 
 The packages database is pulled from the [radare2-pm](https://github.com/radareorg/radare2-pm) repository. At any point of the time we can update the database using `r2pm -U`:
 
-```
-r2pm -U
+```console
+$ r2pm -U
 HEAD is now at 7522928 Fix syntax
 Updating 7522928..1c139e0
 Fast-forward
@@ -43,7 +43,7 @@ Already up to date.
 
 There are many commands available to let you install or uninstall anything easily:
 
-```
+```console
 $ r2pm -h
 Usage: r2pm [-flags] [pkgs...]
 Commands:
@@ -76,7 +76,7 @@ Commands:
 
 For example `lang-python3` (which is used for writing r2 plugins in Python):
 
-```
+```console
 $ r2pm -i lang-python3
 ...
 mkdir -p ~/.config/radare2/plugins
@@ -88,13 +88,13 @@ Note that if we used `-i` switch it installs the plugin in the `$HOME` directory
 
 After this we will be able to see the plugin in the list of installed:
 
-```bash
+```console
 $ r2pm -l
 lang-python3
 ```
 
 To uninstall the plugin just simply run
 
-```bash
+```console
 $ r2pm -u lang-python3
 ```

--- a/src/tools/rabin2/debug_symbols.md
+++ b/src/tools/rabin2/debug_symbols.md
@@ -55,7 +55,7 @@ sometimes for a quick understanding of the symbols stored in it.
 Apart from the basic scenario of just opening a file, PDB information can be additionally
 manipulated by the `id` commands:
 
-```
+```console
 [0x000051c0]> id?
 |Usage: id Debug information
 | Output mode:
@@ -79,7 +79,7 @@ related PDB files will be loaded automatically.
 DWARF information loading, on the other hand, is completely automated. You don't
 need to run any commands/change any options:
 
-```
+```console
 r2 `which rabin2`
 [0x00002437 8% 300 /usr/local/bin/rabin2]> pd $r
 0x00002437  jne 0x2468                  ;[1]

--- a/src/tools/rabin2/entrypoints.md
+++ b/src/tools/rabin2/entrypoints.md
@@ -2,7 +2,7 @@
 
 The `-e` option passed to rabin2 will show entrypoints for given binary. Two examples:
 
-```
+```console
 $ rabin2 -e /bin/ls
 [Entrypoints]
 vaddr=0x00005310 paddr=0x00005310 baddr=0x00000000 laddr=0x00000000 haddr=0x00000018 type=program

--- a/src/tools/rabin2/exports.md
+++ b/src/tools/rabin2/exports.md
@@ -2,7 +2,7 @@
 
 Rabin2 is able to find exports. For example:
 
-```
+```console
 $ rabin2 -E /usr/lib/libr_bin.so | head
 [Exports]
 

--- a/src/tools/rabin2/file_identification.md
+++ b/src/tools/rabin2/file_identification.md
@@ -2,7 +2,7 @@
 
 File type identification is done using `-I`. With this option, rabin2 prints information on a binary type, like its encoding, endianness, class, operating system:
 
-```
+```console
 $ rabin2 -I /bin/ls
 arch     x86
 binsz    128456
@@ -35,7 +35,7 @@ va       true
 
 To make rabin2 output information in format that the main program, radare2, can understand, pass `-Ir` option to it:
 
-```
+```console
 $ rabin2 -Ir /bin/ls
 e cfg.bigendian=false
 e asm.bits=64

--- a/src/tools/rabin2/imports.md
+++ b/src/tools/rabin2/imports.md
@@ -2,7 +2,7 @@
 
 Rabin2 is able to find imported objects by an executable, as well as their offsets in its PLT. This information is useful, for example, to understand what external function is invoked by `call` instruction. Pass `-i` flag to rabin2 to get a list of imports. An example:
 
-```
+```console
 $ rabin2 -i /bin/ls
 [Imports]
 nth vaddr      bind   type   lib name

--- a/src/tools/rabin2/libraries.md
+++ b/src/tools/rabin2/libraries.md
@@ -2,7 +2,7 @@
 
 Rabin2 can list libraries used by a binary with the `-l` option:
 
-```
+```console
 $ rabin2 -l `which r2`
 [Linked libraries]
 libr_core.so
@@ -33,7 +33,7 @@ libc.so.6
 
 Lets check the output with `ldd` command:
 
-```
+```console
 $ ldd `which r2`
 linux-vdso.so.1 (0x00007fffba38e000)
 libr_core.so => /usr/lib64/libr_core.so (0x00007f94b4678000)

--- a/src/tools/rabin2/operations.md
+++ b/src/tools/rabin2/operations.md
@@ -3,7 +3,7 @@
 rabin2 allows you to do some modifications/extraction operations on a file. You do so with **-O** option
 and one of the predefined strings to specify the required operation. All the possible strings are:
 
-```
+```console
 $ rabin2 -O h
 Operation string:
   Change Entrypoint: e/0x8048000

--- a/src/tools/rabin2/program_sections.md
+++ b/src/tools/rabin2/program_sections.md
@@ -2,7 +2,7 @@
 
 Rabin2 called with the `-S` option gives complete information about the sections of an executable. For each section the index, offset, size, alignment, type and permissions, are shown. The next example demonstrates this:
 
-```
+```console
 $ rabin2 -S /bin/ls
 [Sections]
 
@@ -39,7 +39,7 @@ nth paddr          size vaddr         vsize perm name
 
 With the `-Sr` option, rabin2 will flag the start/end of every section, and will pass the rest of information as a comment.
 
-```
+```console
 $ rabin2 -Sr /bin/ls | head
 fs sections
 "f section. 1 0x00000000"

--- a/src/tools/rabin2/strings.md
+++ b/src/tools/rabin2/strings.md
@@ -2,7 +2,7 @@
 
 The `-z` option is used to list readable strings found in the .rodata section of ELF binaries, or the .text section of PE files. Example:
 
-```
+```console
 $ rabin2 -z /bin/ls | head
 [Strings]
 nth paddr      vaddr      len size section type  string
@@ -22,7 +22,7 @@ nth paddr      vaddr      len size section type  string
 With the `-zr` option, this information is represented as a radare2 commands list. It can be used in a radare2 session to automatically create a flag space called "strings" pre-populated with flags for all strings found by rabin2.
 Furthermore, this script will mark corresponding byte ranges as strings instead of code.
 
-```
+```console
 $ rabin2 -zr /bin/ls | head
 fs stringsf str.dev_ino_pop 12 @ 0x000160f8
 Cs 12 @ 0x000160f8

--- a/src/tools/rabin2/symbols.md
+++ b/src/tools/rabin2/symbols.md
@@ -2,8 +2,8 @@
 
 With rabin2, the generated symbols list format is similar to the imports list. Use the `-s` option to get it:
 
-```
-rabin2 -s /bin/ls | head
+```console
+$ rabin2 -s /bin/ls | head
 [Symbols]
 
 nth paddr       vaddr      bind   type   size lib name
@@ -21,7 +21,7 @@ nth paddr       vaddr      bind   type   size lib name
 
 With the `-sr` option rabin2 produces a radare2 script instead. It can later be passed to the core to automatically flag all symbols and to define corresponding byte ranges as functions and data blocks.
 
-```
+```console
 $ rabin2 -sr /bin/ls | head
 fs symbols
 f sym.obstack_allocated_p 56 0x000150a0

--- a/src/tools/radiff2/binary_diffing.md
+++ b/src/tools/radiff2/binary_diffing.md
@@ -4,7 +4,7 @@ This section is based on the <https://radare.today> article "[binary diffing](ht
 
 Without any parameters, `radiff2` by default shows what bytes are changed and their corresponding offsets:
 
-```
+```console
 $ radiff2 genuine cracked
 0x000081e0 85c00f94c0 => 9090909090 0x000081e0
 0x0007c805 85c00f84c0 => 9090909090 0x0007c805
@@ -18,7 +18,7 @@ Notice how the two jumps are nop'ed.
 
 For bulk processing, you may want to have a higher-level overview of differences. This is why radare2 is able to compute the distance and the percentage of similarity between two files with the `-s` option:
 
-```
+```console
 $ radiff2 -s /bin/true /bin/false
 similarity: 0.97
 distance: 743
@@ -26,14 +26,14 @@ distance: 743
 
 If you want more concrete data, it's also possible to count the differences, with the `-c` option:
 
-```
+```console
 $ radiff2 -c genuine cracked
 2
 ```
 
 If you are unsure whether you are dealing with similar binaries, with `-C` flag you can check there are matching functions. It this mode, it will give you three columns for all functions: "First file offset", "Percentage of matching" and "Second file offset".
 
-```
+```console
 $ radiff2 -C /bin/false /bin/true
   entry0  0x4013e8 |   MATCH  (0.904762) | 0x4013e2  entry0
   sym.imp.__libc_start_main  0x401190 |   MATCH  (1.000000) | 0x401190  sym.imp.__libc_start_main
@@ -47,7 +47,7 @@ $ radiff2 -C /bin/false /bin/true
 Moreover, we can ask radiff2 to perform analysis first - adding `-A` option will run `aaa` on the binaries.
 And we can specify binaries architecture for this analysis too using
 
-```
+```console
 $ radiff2 -AC -a x86 /bin/true /bin/false | grep UNMATCH
 [x] Analyze all flags starting with sym. and entry0 (aa)
 [x] Analyze len bytes of instructions for references (aar)

--- a/src/tools/radiff2/codediff.md
+++ b/src/tools/radiff2/codediff.md
@@ -6,7 +6,7 @@ To understand this feature we will start by using the basic delta diffing from t
 
 Note that radiff2 permits to specify the arch/bits/.. settings using these flags:
 
-```
+```console
 $ radiff2 -h | grep -e arch -e bits
 -a [arch]  specify architecture plugin to use (x86, arm, ..)
 -b [bits]  specify register size for arch (16 (thumb), 32, 64, ..)
@@ -14,7 +14,7 @@ $ radiff2 -h | grep -e arch -e bits
 
 Let's test it out!
 
-```
+```console
 $ cat 1
 j0X40PZHf5sOf5A0PRXRj0X40hXXshXf5wwPj0X4050binHPTXRQSPTUVWaPYS4J4A
 $ cat 2
@@ -23,7 +23,7 @@ j0X4PX0PZHf5sOf5A0PRXRj0X40hXXshXf5wwPj0X4050binHPTXRQSPTUVWaPYS4J
 
 Wen can compare the changes as disassembly like this:
 
-```
+```console
 $ radiff2 -D 5 6
   push 0x30
   pop rax

--- a/src/tools/radiff2/datadiff.md
+++ b/src/tools/radiff2/datadiff.md
@@ -4,7 +4,7 @@ Data diffing with radiff2 allows you to compare binary data between files of dif
 
 For example, comparing two files with `radiff2 -x` shows the differences in two column hexdump+ascii format:
 
-```
+```console
 $ cat 1
 hello
 $ cat 2
@@ -16,14 +16,14 @@ $ radiff2 -x 1 2
 
 Also in hexII format:
 
-```
+```console
 $ radiff2 -X 1 2
 0x00000000! .h.e.l.l.o0a         .h.a.l.l.o0a    
 ```
 
 or even the unified diff format using the `-U` flag:
 
-```
+```console
 $ radiff2 -U 1 2
 --- /tmp/r_diff.61dd4e41da041	2024-07-22 14:07:37.682683431 +0200
 +++ /tmp/r_diff.61dd4e41da06b	2024-07-22 14:07:37.682683431 +0200
@@ -40,7 +40,7 @@ Let's understand the output because in your terminal you'll see some green and r
 
 When comparing files of different sizes, we will need to use the `-d` flag which performs a delta-diffing algorithm, trying to find the patterns of bytes that has been added or removed when a specific change is found.
 
-```sh
+```console
 $ cat 1 
 hello
 $ cat 3
@@ -57,7 +57,7 @@ $
 
 For JSON output, use radiff2 -j -d to get detailed diff information in JSON format:
 
-```
+```console
 $ radiff2 -j -d 1 3 |jq .
 INFO: File size differs 6 vs 11
 {

--- a/src/tools/radiff2/intro.md
+++ b/src/tools/radiff2/intro.md
@@ -10,7 +10,7 @@ Many of these diffing features are also available in the `c` command within the 
 
 You can learn more about this tool by checking the help message or reading the manpage with `man radiff2`.
 
-```
+```console
 $ radiff2 -h
 Usage: radiff2 [-abBcCdjrspOxuUvV] [-A[A]] [-g sym] [-m graph_mode][-t %] [file] [file]
   -a [arch]  specify architecture plugin to use (x86, arm, ..)
@@ -95,7 +95,7 @@ radiff2 -O bin1 bin2
 
 To compare two binaries and generate a patch file, you can use the following command:
 
-```sh
+```console
 $ echo hello > 1
 $ echo hallo > 2
 $ radiff2 -r 1 2
@@ -107,7 +107,7 @@ $
 
 Note the `-r` flag will generate an r2 script, which can then be used to generate one binary from the other one using radare2 like this:
 
-```sh
+```console
 $ rahash2 -a md5 1 2
 1: 0x00000000-0x00000005 md5: b1946ac92492d2347c6235b4d2611184
 2: 0x00000000-0x00000005 md5: aee97cb3ad288ef0add6c6b5b5fae48a

--- a/src/tools/rafind2/intro.md
+++ b/src/tools/rafind2/intro.md
@@ -2,7 +2,7 @@
 
 Rafind2 is the command line fronted of the `r_search` library. Which allows you to search for strings, sequences of bytes with binary masks, etc
 
-```
+```console
 $ rafind2 -h
 Usage: rafind2 [-mXnzZhqv] [-a align] [-b sz] [-f/t from/to] [-[e|s|S] str] [-x hex] -|file|dir ..
  -a [align] only accept aligned hits
@@ -29,7 +29,7 @@ Usage: rafind2 [-mXnzZhqv] [-a align] [-b sz] [-f/t from/to] [-[e|s|S] str] [-x 
 
 That's how to use it, first we'll search for "lib" inside the `/bin/ls` binary.
 
-```
+```console
 $ rafind2 -s lib /bin/ls
 0x5f9
 0x675
@@ -42,13 +42,13 @@ Note that the output is pretty minimal, and shows the offsets where the string `
 
 Counting results:
 
-```
+```console
 $ rafind2 -s lib /bin/ls | wc -l
 ```
 
 Displaying results with context:
 
-```
+```console
 $ export F=/bin/ls
 $ for a in `rafind2 -s lib $F` ; do \
     r2 -ns $a -qc'x 32' $F ; done
@@ -66,14 +66,14 @@ $ for a in `rafind2 -s lib $F` ; do \
 
 rafind2 can also be used as a replacement of `file` to identify the mimetype of a file using the internal magic database of radare2.
 
-```
+```console
 $ rafind2 -i /bin/ls
 0x00000000 1 Mach-O
 ```
 
 Also works as a `strings` replacement, similar to what you do with rabin2 -z, but without caring about parsing headers and obeying binary sections.
 
-```
+```console
 $ rafind2 -z /bin/ls| grep http
 0x000076e5 %http://www.apple.com/appleca/root.crl0\r
 0x00007ae6 https://www.apple.com/appleca/0

--- a/src/tools/ragg2/encoders.md
+++ b/src/tools/ragg2/encoders.md
@@ -2,7 +2,7 @@
 
 ragg2 offers a few ready-made shellcodes and encoders.
 
-```sh
+```console
 $ ragg2 -L
 shellcodes:
       exec : execute cmd=/bin/sh suid=false
@@ -12,7 +12,7 @@ encoders:
 
 Using the '-i' option, one can generate specify and generate the shellcode.
 
-```sh
+```console
 $ ragg2 -i exec
 31c048bbd19d9691d08c97ff48f7db53545f995257545eb03b0f05
 ```
@@ -21,21 +21,21 @@ Similar to the previous section, the output format(c, raw, elf etc.,) can be spe
 
 ragg2 offers an xor encoder too. The following are the relevant flags/options.
 
-```sh
+```console
 $ ragg2 -h
  -c [k=v]        set configuration options
  -E [encoder]    use specific encoder. see -L
  -L              list all plugins (shellcodes and encoders)
 ```
 
-```sh
+```console
 $ ragg2 -E xor -c key=32 -i exec
 6a1b596a205be8ffffffffc15e4883c60d301e48ffc6e2f911e0689bf1bdb6b1f0acb7df68d7fb73747fb97277747e901b2f25
 ```
 
 The same can be done with a .c or .r file output. The first one is the normal output(machine code) and the second is xor encoded.
 
-```sh
+```console
 $ ragg2 -a x86 -f raw code1.c
 eb0e66666666662e0f1f84000000000050bf01000000488d359f000000ba0d000000e81900000031ff89442404e85e00000031d289042489d059c30f1f440000897c24fc48897424f0895424ec8b5424fc895424dc488b7424f048897424d08b5424ec895424cc8b7c24dc488b7424d08b5424ccb8010000000f0548894424e0488b4424e089c1894c24c88b4424c8c3897c24fc8b7c24fc897c24ec8b7c24ecb83c0000000f0548894424f0488b4424f089c1894c24e88b4424e8c348656c6c6f20576f726c640a00
 

--- a/src/tools/ragg2/lang.md
+++ b/src/tools/ragg2/lang.md
@@ -30,7 +30,7 @@ Use `cat(1)` or the preprocessor to concatenate multiple files to be compiled.
 
 eggs can use a hashbang to make them executable.
 
-```sh
+```console
 $ head -n1 hello.r
 #!/usr/bin/ragg2 -X
 $ ./hello.r
@@ -41,7 +41,7 @@ Hello World!
 
 The execution of the code is done as in a flow. The first function to be defined will be the first one to be executed. If you want to run main\(\) just do like this:
 
-```
+```sh
 #!/usr/bin/ragg2 -X
 main();
   ...
@@ -123,7 +123,7 @@ Supported as raw pointers. TODO: enhance this feature
 
 Sometimes r\_egg programs will break or just not work as expected. Use the 'trace' architecture to get a arch-backend call trace:
 
-```sh
+```console
 $ ragg2 -a trace -s yourprogram.r
 ```
 
@@ -145,7 +145,7 @@ Ragg2 supports local variables assignment by math operating, including the follo
 
 The return value is stored in the a0 register, this register is set when calling a function or when typing a variable name without assignment.
 
-```sh
+```console
 $ cat test.r
 add@global(4) {
 	.var0 = .arg0 + .arg1;

--- a/src/tools/ragg2/ragg2.md
+++ b/src/tools/ragg2/ragg2.md
@@ -19,7 +19,7 @@ int main() {
 
 That small C program can be compiled with ragg2 like this:
 
-```
+```console
 $ ragg2 -a x86 -b32 a.c
 e900000000488d3516000000bf01000000b80400000248c7c20d0000000f0531c0c348656c6c6f20576f726c640a00
 
@@ -88,7 +88,7 @@ Usage: ragg2 [-FOLsrxhvz] [-a arch] [-b bits] [-k os] [-o file] [-I path]
 
 ### First Example
 
-```
+```console
 $ cat hello.r
 exit@syscall(1);
 
@@ -135,14 +135,14 @@ int main()
 
 One can get raw machine code of the above program like this:
 
-```sh
+```console
 $ ragg2 code1.c
 eb0e66666666662e0f1f84000000000050bf01000000488d359f000000ba0d000000e81900000031ff89442404e85e00000031d289042489d059c30f1f440000897c24fc48897424f0895424ec8b5424fc895424dc488b7424f048897424d08b5424ec895424cc8b7c24dc488b7424d08b5424ccb8010000000f0548894424e0488b4424e089c1894c24c88b4424c8c3897c24fc8b7c24fc897c24ec8b7c24ecb83c0000000f0548894424f0488b4424f089c1894c24e88b4424e8c348656c6c6f20576f726c640a00
 ```
 
 If you want it in a file, you may use the '-O' flag which uses the default filename or you may specify the output filename using '-o' option.
 
-```sh
+```console
 $ ragg2 -O code1.c
 $ cat code1
 eb0e66666666662e0f1f84000000000050bf01000000488d359f000000ba0d000000e81900000031ff89442404e85e00000031d289042489d059c30f1f440000897c24fc48897424f0895424ec8b5424fc895424dc488b7424f048897424d08b5424ec895424cc8b7c24dc488b7424d08b5424ccb8010000000f0548894424e0488b4424e089c1894c24c88b4424c8c3897c24fc8b7c24fc897c24ec8b7c24ecb83c0000000f0548894424f0488b4424f089c1894c24e88b4424e8c348656c6c6f20576f726c640a00
@@ -150,7 +150,7 @@ eb0e66666666662e0f1f84000000000050bf01000000488d359f000000ba0d000000e81900000031
 
 Printing as in raw
 
-```sh
+```console
 $ ragg2 -o code1.raw code1.c
 $ cat code1.raw
 eb0e66666666662e0f1f84000000000050bf01000000488d359f000000ba0d000000e81900000031ff89442404e85e00000031d289042489d059c30f1f440000897c24fc48897424f0895424ec8b5424fc895424dc488b7424f048897424d08b5424ec895424cc8b7c24dc488b7424d08b5424ccb8010000000f0548894424e0488b4424e089c1894c24c88b4424c8c3897c24fc8b7c24fc897c24ec8b7c24ecb83c0000000f0548894424f0488b4424f089c1894c24e88b4424e8c348656c6c6f20576f726c640a00
@@ -164,7 +164,7 @@ The above is a basic 'raw' output. ragg2 offers a number of output format option
 
 The following is 'c' format output - shellcode which can be readily used in your C program.
 
-```sh
+```console
 $ ragg2 -f c -o code1.c.c code1.c
 $ cat code1.c.c
 const unsigned char cstr[201] = ""\
@@ -204,7 +204,7 @@ int main()
 
 Compile and run it.
 
-```
+```console
 $ gcc code1.c.c -o code1.c.elf -zexecstack
 code1.c.c: In function ‘main’:
 code1.c.c:14:19: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
@@ -218,7 +218,7 @@ Similar to how the above code is readily usable in C programs, ragg2 can emit py
 
 To generate an executable binary for your native architecture, you may use the '-F' option.
 
-```sh
+```console
 $ ragg2 -F -o code1.elf code1.c
 $ ./code1.elf
 Hello World
@@ -226,7 +226,7 @@ Hello World
 
 You may specify the binary format output.
 
-```sh
+```console
 $ ragg2 -f elf -o code1_f.elf code1.c
 $ ./code1_f.elf
 Hello World
@@ -234,7 +234,7 @@ Hello World
 
 or
 
-```sh
+```console
 $ ragg2 -f mach0 -o code1_f.mach0 code1.c
 $ file code1_f.mach0
 code1_f.mach0: Mach-O 64-bit x86_64 executable
@@ -244,7 +244,7 @@ Same with the 'PE' format.
 
 In the above examples, the target architecture is the architecture of your machine. But target architecture can explicitly be specified using the '-a' option.
 
-```sh
+```console
 $ ragg2 -f raw -a x86 -b 32 code1.c
 eb4e66666666662e0f1f840000000000575683ec108b4424208b4c241c8b54241c8b742420bf66000000894c240889f18944240489f85389d3cd805b8944240c8b44240c8904248b042483c4105e5fc3535683ec24e8000000005881c0661e0000b9010000008d9083e2ffffbe0d000000c704240100000089542404c74424080d00000089c389442420894c241c89742418e82900000031c9c70424000000008b5c242089442414894c2410e86f00000031c083c4245e5bc30f1f80000000005553575683ec148b4424308b4c242c8b5424288b7424288b7c242c8b5c2430bd04000000894c240c89f98954240889da8944240489e85389f3cd805b894424108b4424108904248b042483c4145e5f5b5dc366666666662e0f1f84000000000083ec088b44240c8b4c240cba0100000089042489d05389cbcd805b8944240483c408c348656c6c6f20576f726c640a00
 ```
@@ -258,7 +258,7 @@ The '-b' option can be used to specify the bits. One can see the supported archi
 
 The '-r' flag can be used to generate binary output instead of the above hex-string style output.
 
-```sh
+```console
 $ ragg2 -f raw -r code1.c | rax2 -S
 efbfbd31efbfbdefbfbd4424efbfbd5e31d28924efbfbdefbfbd59efbfbd44efbfbd7c24efbfbd48efbfbd
 7424efbfbdefbfbd5424efbfbdefbfbd5424efbfbdefbfbd5424efbfbd48efbfbd7424efbfbd48efbfbd74
@@ -268,7 +268,7 @@ bfbd4424efbfbdefbfbdefbfbdefbfbd4c24c88b4424efbfbdc3897c24efbfbdefbfbd7c24efbfbd
 bd4c24efbfbdefbfbd4424efbfbdefbfbd48656c6c6f20576f726c640a
 ```
 
-```
+```console
 $ ragg2 -f raw -a x86 -b 64 -r code1.c | xxd
 00000000: eb0e 6666 6666 662e 0f1f 8400 0000 0000  ..fffff.........
 00000010: 50bf 0100 0000 488d 359f 0000 00ba 0d00  P.....H.5.......
@@ -287,7 +287,7 @@ $ ragg2 -f raw -a x86 -b 64 -r code1.c | xxd
 
 Using '-z' flag instead of '-r' would generate a C-style hex-string output.
 
-```sh
+```console
 $ ragg2 -f raw -z code1.c
 "\xeb\x0e\x66\x66\x66\x66\x66\x2e\x0f\x1f\x84\x00\x00\x00\x00\x00\x50\xbf\x01\x00\x00\x00\x48\x8d\x35\x9f\x00\x00\x00\xba\x0d\x00\x00\x00\xe8\x19\x00\x00\x00\x31\xff\x89\x44\x24\x04\xe8\x5e\x00\x00\x00\x31\xd2\x89\x04\x24\x89\xd0\x59\xc3\x0f\x1f\x44\x00\x00\x89\x7c\x24\xfc\x48\x89\x74\x24\xf0\x89\x54\x24\xec\x8b\x54\x24\xfc\x89\x54\x24\xdc\x48\x8b\x74\x24\xf0\x48\x89\x74\x24\xd0\x8b\x54\x24\xec\x89\x54\x24\xcc\x8b\x7c\x24\xdc\x48\x8b\x74\x24\xd0\x8b\x54\x24\xcc\xb8\x01\x00\x00\x00\x0f\x05\x48\x89\x44\x24\xe0\x48\x8b\x44\x24\xe0\x89\xc1\x89\x4c\x24\xc8\x8b\x44\x24\xc8\xc3\x89\x7c\x24\xfc\x8b\x7c\x24\xfc\x89\x7c\x24\xec\x8b\x7c\x24\xec\xb8\x3c\x00\x00\x00\x0f\x05\x48\x89\x44\x24\xf0\x48\x8b\x44\x24\xf0\x89\xc1\x89\x4c\x24\xe8\x8b\x44\x24\xe8\xc3\x48\x65\x6c\x6c\x6f\x20\x57\x6f\x72\x6c\x64\x0a\x00"
 ```
@@ -296,14 +296,14 @@ Instead of using C, a domain specific language designed for ragg2 can also be us
 
 The `-e` option can be used if you want to input the code as an argument to ragg2 and not as a file. Note that you can only use ragg2 language here(and not C).
 
-```sh
+```console
 $ ragg2 -e "exit@syscall(60); write@syscall(4); main@global(128) {write(1, \"Hello World\n\", 13); exit(0);}" 
 554889e54881ec8000000048c7c00d00000050c7452048656c6cc745246f20576fc74528726c640ac7452c00000000c7453000000000488d452048898518000000488b45185048c7c00100000050488b3c24488b742408488b54241048c7c0040000000f054883c41848c7c00000000050488b3c2448c7c03c0000000f054883c4084881c4800000005dc3
 ```
 
 Other options like architecture, bits, output file format etc., can be used here too.
 
-```sh
+```console
 $ ragg2 -e "exit@syscall(60); write@syscall(4); main@global(128) {write(1, \"Hello World\n\", 13); exit(0);}"  -f elf -o output.elf
 $ file output.elf
 output.elf: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, corrupted section header size
@@ -324,7 +324,7 @@ In case you just want to execute the input, you may use the `-x` option.
 -x          execute (just-in-time)
 ```
 
-```sh
+```console
 $ cat code1.c
 int main()
 {

--- a/src/tools/rahash2/encode.md
+++ b/src/tools/rahash2/encode.md
@@ -2,7 +2,7 @@
 
 As mentioned before, this tool also provide the tooling needed to encode and decode between different encodings
 
-```
+```console
 $ rahash2 -L | grep ^e
 e  base64
 e  base91
@@ -11,7 +11,7 @@ e  punycode
 
 For example, to encode a string into base64 use the following line:
 
-```
+```console
 $ rahash2 -E base64 -s hello
 ```
 
@@ -21,7 +21,7 @@ You can decode it by using the -D flag instead of -E.
 
 For encrypting data check the crypto hash plugins:
 
-```
+```console
 $ rahash2 -L | grep ^c
 c  rc2
 c  rc4
@@ -40,7 +40,7 @@ c  serpent-ecb
 
 Here's an example usage to encrypt a string using rahash2:
 
-```
+```console
 $ rahash2 -E xor -S s:password -s hello | hexdump -C
 00000000  18 04 1f 1f 18
 ```

--- a/src/tools/rahash2/intro.md
+++ b/src/tools/rahash2/intro.md
@@ -24,7 +24,7 @@ Key features of rahash2 include:
 
 This is an example usage:
 
-```
+```console
 $ rahash2 -a md5 -s "hello world"
 ```
 
@@ -40,7 +40,7 @@ It can also be used to find which blocks have changed between more than one samp
 
 This can be useful when analyzing ram dumps from a virtual machine for example. Use this command for this:
 
-```
+```console
 $ rahash2 -B 1M -b -a sha256 /bin/ls
 ```
 
@@ -48,7 +48,7 @@ $ rahash2 -B 1M -b -a sha256 /bin/ls
 
 The rabin2 tool parses the binary headers of the files, but it also have the ability to use the rhash plugins to compute checksum of sections in the binary.
 
-```
+```console
 $ rabin2 -K md5 -S /bin/ls
 ```
 
@@ -56,7 +56,7 @@ $ rabin2 -K md5 -S /bin/ls
 
 To calculate a checksum of current block when running radare2, use the `ph` command. Pass an algorithm name to it as a parameter. An example session:
 
-```
+```console
 $ radare2 /bin/ls
 [0x08049790]> bf entry0
 [0x08049790]> ph md5
@@ -65,7 +65,7 @@ d2994c75adaa58392f953a448de5fba7
 
 You can use all hashing algorithms supported by `rahash2`:
 
-```
+```console
 [0x00000000]> ph?
 md5
 sha1
@@ -109,7 +109,7 @@ crc64iso
 
 The `ph` command accepts an optional numeric argument to specify length of byte range to be hashed, instead of default block size. For example:
 
-```
+```console
 [0x08049A80]> ph md5 32
 9b9012b00ef7a94b5824105b7aaad83b
 [0x08049A80]> ph md5 64

--- a/src/tools/rahash2/rahash_tool.md
+++ b/src/tools/rahash2/rahash_tool.md
@@ -2,7 +2,7 @@
 
 The rahash2 tool can be used to calculate checksums and has functions of byte streams, files, text strings.
 
-```
+```console
 $ rahash2 -h
 Usage: rahash2 [-rBhLkv] [-b S] [-a A] [-c H] [-E A] [-s S] [-f O] [-t O] [file] ...
  -a algo     comma separated list of algorithms (default is 'sha256')
@@ -29,7 +29,7 @@ Usage: rahash2 [-rBhLkv] [-b S] [-a A] [-c H] [-E A] [-s S] [-f O] [-t O] [file]
 
 To obtain an MD5 hash value of a text string, use the `-s` option:
 
-```
+```console
 $ rahash2 -q -a md5 -s 'hello world'
 5eb63bbbe01eeed093cb22bb8f5acdc3
 ```
@@ -38,7 +38,7 @@ It is possible to calculate hash values for contents of files. But do not attemp
 
 To apply all algorithms known to rahash2, use `all` as an algorithm name:
 
-```
+```console
 $ rahash2 -a all /bin/ls
 /bin/ls: 0x00000000-0x000268c7 md5: 767f0fff116bc6584dbfc1af6fd48fc7
 /bin/ls: 0x00000000-0x000268c7 sha1: 404303f3960f196f42f8c2c12970ab0d49e28971

--- a/src/tools/rarun2/intro.md
+++ b/src/tools/rarun2/intro.md
@@ -2,7 +2,7 @@
 
 Rarun2 is a tool allowing to setup a specified execution environment - redefine stdin/stdout, pipes, change the environment variables and other settings useful to craft the boundary conditions you need to run a binary for debugging.
 
-```bash
+```console
 $ rarun2 -h
 Usage: rarun2 -v|-t|script.rr2 [directive ..]
 ```
@@ -17,7 +17,7 @@ One of the most common usage cases - redirect the output of debugged program in 
 
 Here is the basic profile example:
 
-```
+```sh
 program=/bin/ls
 arg1=/bin
 # arg2=hello
@@ -75,7 +75,7 @@ When this script is executed with rarun2, it will:
 
 This setup is often used for debugging, testing, or analyzing programs in a controlled environment, especially in the context of reverse engineering or security research.
 
-```bash
+```console
 $ cat foo.rr2
 #!/usr/bin/rarun2
 program=./pp400
@@ -88,7 +88,7 @@ chdir=/tmp
 
 ### Using a program via TCP/IP
 
-```
+```console
 $ nc -l 9999
 $ rarun2 program=/bin/ls connect=localhost:9999
 ```
@@ -97,7 +97,7 @@ $ rarun2 program=/bin/ls connect=localhost:9999
 
 1 - open a new terminal and type 'tty' to get a terminal name:
 
-```
+```console
 $ tty ; clear ; sleep 999999
 /dev/ttyS010
 ```
@@ -112,6 +112,6 @@ stdio=/dev/ttys010
 
 3 - Launch the following radare2 command:
 
-```bash
+```console
 $ r2 -r foo.rr2 -d /bin/ls
 ```

--- a/src/tools/rasign2/intro.md
+++ b/src/tools/rasign2/intro.md
@@ -2,7 +2,7 @@
 
 The `rasign2` tool allows you to quickly create signature files. To create a SDB signature file named `libc_sigs2.sdb` for the `libc.so.6` binary, simply run:
 
-```
+```console
 $ rasign2 -o libc_sigs2.sdb libc.so.6
 [x] Analyze all flags starting with sym. and entry0 (aa)
 generated zignatures: 2870
@@ -10,7 +10,7 @@ generated zignatures: 2870
 
 The above is equivalent to:
 
-```
+```console
 $ r2 libc.so.6
 [0x00024330]> aa # analyze the file finding functions
 [x] Analyze all flags starting with sym. and entry0 (aa)
@@ -21,7 +21,7 @@ generated zignatures: 2870
 
 The '-a' flag can be added to increase the amount of analysis performed. This will result in more functions discovered and more zignatures created.
 
-```
+```console
 $ rasign2 -a -o /tmp/libc_sigs2.sdb libc.so.6
 [x] Analyze all flags starting with sym. and entry0 (aa)
 [x] Analyze function calls (aac)
@@ -38,7 +38,7 @@ generated zignatures: 2955
 
 There are 3 different output methods. Using `-o` to create an SDB is shown above. The `-r` flag will print the discovered signatures to stdout as r2 commands.
 
-```
+```console
 $ rasign2 -r hello_world  |grep main
 [x] Analyze all flags starting with sym. and entry0 (aa)
 generated zignatures: 17
@@ -53,8 +53,8 @@ za main h 44004dffff87483150d4f315ea8426b4d0c471ce4c56176c874513b24d0266b4
 
 The `-j` flag will print results in JSON format.
 
-```
-rasign2 -j hello_world
+```console
+$ rasign2 -j hello_world
 [x] Analyze all flags starting with sym. and entry0 (aa)
 generated zignatures: 17
 [{"name":"main","bytes":"554889e54883ec20488d051b01000048894...
@@ -62,8 +62,8 @@ generated zignatures: 17
 
 See the help menu for more details:
 
-```
-rasign2 -h
+```console
+$ rasign2 -h
 Usage: rasign2 [options] [file]
  -a [-a]          add extra 'a' to analysis command
  -o sigs.sdb      add signatures to file, create if it does not exist

--- a/src/tools/rasm2/assemble.md
+++ b/src/tools/rasm2/assemble.md
@@ -6,14 +6,14 @@ In radare2, the assembler and disassembler logic is implemented in the r_asm_* A
 
 Rasm2 can be used to quickly copy-paste hexpairs that represent a given machine instruction. The following line is assembling this mov instruction for x86/32.
 
-```
+```console
 $ rasm2 -a x86 -b 32 'mov eax, 33'
 b821000000
 ```
 
 Apart from the specifying the input as an argument, you can also pipe it to rasm2:
 
-```
+```console
 $ echo 'push eax;nop;nop' | rasm2 -f -
 5090
 ```
@@ -60,7 +60,7 @@ selfstop:
 
 Now we can assemble it in place:
 
-```
+```console
 [0x00000000]> e asm.bits = 32
 [0x00000000]> wx `!rasm2 -f a.rasm`
 [0x00000000]> pd 20

--- a/src/tools/rasm2/disassemble.md
+++ b/src/tools/rasm2/disassemble.md
@@ -4,14 +4,14 @@ Disassembling is the inverse action of assembling. Rasm2 takes hexpair as an inp
 
 To do this we can use the `-d` option of rasm2 like this:
 
-```
+```console
 $ rasm2 -a x86 -b 32 -d '90'
 nop
 ```
 
 or for java:
 
-```sh
+```console
 $ rasm2 -a java 'nop'
 00
 
@@ -19,7 +19,7 @@ Rasm2 also have the `-D` flag to show the disassembly like `-d` does, but includ
 
 In radare2 there are many commands to perform a disassembly from a specific place in memory.
 
-```sh
+```console
 $ rasm2 -a x86 -b 32 'mov eax, 33'
 b821000000
 

--- a/src/tools/rasm2/intro.md
+++ b/src/tools/rasm2/intro.md
@@ -12,7 +12,7 @@ The command-line assembler and disassembler that is part of the radare2 framewor
 
 ### Help
 
-```
+```console
 $ rasm2 -h
 Usage: rasm2 [-ACdDehLBvw] [-a arch] [-b bits] [-o addr] [-s syntax]
              [-f file] [-F fil:ter] [-i skip] [-l len] 'code'|hex|0101b|-
@@ -59,7 +59,7 @@ Environment:
 
 Plugins for supported target architectures can be listed with the `-L` option. Knowing a plugin name, you can use it by specifying its name to the `-a` option
 
-```
+```console
 $ rasm2 -L
 _dAe  8 16       6502        LGPL3   6502/NES/C64/Tamagotchi/T-1000 CPU
 _dAe  8          8051        PD      8051 Intel CPU

--- a/src/tools/rax2/intro.md
+++ b/src/tools/rax2/intro.md
@@ -6,7 +6,7 @@ This is the help message of rax2, this tool can be used in the command-line or i
 
 Inside r2, the functionality of rax2 is available under the ? command. For example:
 
-```
+```console
 [0x00000000]> ? 3+4
 ```
 
@@ -22,7 +22,7 @@ The syntax in which the numbers are represented define the base, for example:
 
 This is the help message of rax2 -h, which will show you a bunch more syntaxes
 
-```
+```console
 $ rax2 -h
 Usage: rax2 [options] [expr ...]
   =[base]                      ;  rax2 =10 0x46 -> output in base 10
@@ -75,7 +75,7 @@ Some examples:
 
 Calculator:
 
-```sh
+```console
 $ rax2 3+0x80
 0x83
 $ rax2 -d "1<<8"
@@ -84,7 +84,7 @@ $ rax2 -d "1<<8"
 
 Base conversion:
 
-```sh
+```console
 $ rax2 '=2' 73303325
 100010111101000010100011101b
 ```
@@ -93,7 +93,7 @@ The single quote for `'=2'` is not mandatory for bash but is necessary for some 
 
 Conversion in hex string
 
-```sh
+```console
 $ rax2 -s 4142
 AB
 $ rax2 -S AB
@@ -104,7 +104,7 @@ $ rax2 -S < bin.foo
 
 Endianness conversion:
 
-```sh
+```console
 $ rax2 -e 33
 0x21000000
 $ rax2 -e 0x21000000
@@ -113,14 +113,14 @@ $ rax2 -e 0x21000000
 
 Base64 decoding
 
-```sh
+```console
 $ rax2 -D ZQBlAA== | rax2 -S
 65006500
 ```
 
 Randomart:
 
-```sh
+```console
 $ rax2 -K 90203010
 +--[0x10302090]---+
 |Eo. .            |

--- a/src/visual/intro.md
+++ b/src/visual/intro.md
@@ -19,7 +19,7 @@ The Visual mode uses "print modes" which are basically different panels that you
 
 Notice that the top of the panel contains the command which is used, for example for the disassembly panel:
 
-```
+```console
 [0x00404890 16% 120 /bin/ls]> pd $r @ entry0
 ```
 

--- a/src/visual/visual_disassembly.md
+++ b/src/visual/visual_disassembly.md
@@ -113,8 +113,8 @@ Following are some example of eval variable related to disassembly.
 
 You can view the list of all arch using `e asm.arch=?`
 
-```
-e asm.arch = dalvik
+```console
+> e asm.arch = dalvik
 0x00404870      31ed4989       cmp-long v237, v73, v137
 0x00404874      d15e4889       rsub-int v14, v5, 0x8948
 0x00404878      e24883e4       ushr-int/lit8 v72, v131, 0xe4
@@ -122,8 +122,8 @@ e asm.arch = dalvik
 0x00404882      90244100       add-int v36, v65, v0
 ```
 
-```
-e asm.bits = 16
+```console
+> e asm.bits = 16
 0000:4870      31ed           xor bp, bp
 0000:4872      49             dec cx
 0000:4873      89d1           mov cx, dx
@@ -136,8 +136,8 @@ This latest operation can also be done using `&` in Visual mode.
 
 #### asm.pseudo: Enable pseudo syntax
 
-```
-e asm.pseudo = true
+```console
+> e asm.pseudo = true
 0x00404870      31ed           ebp = 0
 0x00404872      4989d1         r9 = rdx
 0x00404875      5e             pop rsi
@@ -147,8 +147,8 @@ e asm.pseudo = true
 
 #### asm.syntax: Select assembly syntax (intel, att, masm...)
 
-```
-e asm.syntax = att
+```console
+> e asm.syntax = att
 0x00404870      31ed           xor %ebp, %ebp
 0x00404872      4989d1         mov %rdx, %r9
 0x00404875      5e             pop %rsi
@@ -158,8 +158,8 @@ e asm.syntax = att
 
 #### asm.describe: Show opcode description
 
-```
-e asm.describe = true
+```console
+> e asm.describe = true
 0x00404870  xor ebp, ebp   ; logical exclusive or
 0x00404872  mov r9, rdx    ; moves data from src to dst
 0x00404875  pop rsi        ; pops last element of stack and stores the result in argument

--- a/src/visual/visual_menus.md
+++ b/src/visual/visual_menus.md
@@ -13,7 +13,7 @@ There are a couple of keystrokes in Visual Mode that will lead to some menus wit
 
 This visual mode can be used to navigate through the program like in the visual disassembly view, but having some extra visual modes to follow references, etc
 
-```
+```console
 [0x00000000]> Vv
 .-- functions ----- pdr ---------------------------------.
 | (a)nalyze   (-)delete (x)xrefs (X)refs (j/k) next/prev |
@@ -37,7 +37,7 @@ The Vd menu can be used to redefine information in the current function or instr
 
 This is the list of actions:
 
-```
+```console
 [0x00000000]> Vd
 [Vd]- Define current block as:                                                                   
  $    define flag size


### PR DESCRIPTION
I have reviewed all fenced code blocks and tried to set the language.

As a summary:
- Any direct shell command that don't start with the prompt `$` or `>` have been set to `sh` lang.
- Any console capture like starting with a prompt (`$` or `>` or radare prompt) have been set to `console` lang.
  - In some instances the prompt have been added since the output was actually a console capture.
- Some exceptions have been made when most of the console output is in C or other format.
- Other blocks have been detected to be `bat` or `ini` (windows sections).
