### PR TITLE
Minor commandline_flags.md fix

### DIFF
--- a/src/first_steps/commandline_flags.md
+++ b/src/first_steps/commandline_flags.md
@@ -82,7 +82,7 @@ Open a file in write mode and do not parse the headers (raw mode).
 $ r2 -nw file
 ```
 
-Quickly get into the r2 shell opening a 1KB malloc virtual file, handy for testing things. note that a single dash is an alias for malloc://1024
+Quickly get into the r2 shell opening a 512B malloc virtual file, handy for testing things. note that a single dash is an alias for malloc://512
 
 ```console
 $ r2 -


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [x] I wrote some documentation

**Description**

Change 1KB -> 512B, which is the default behavior:

```
$ man radare2 | grep -i malloc://
       -           Equivalent of 'r2 malloc://512'
```
```
[vagrant@fedora40 radare2]$ r2 -v
radare2 5.9.5 32531 @ linux-x86-64
birth: git.5.9.4-150-gb46f70a4bf 2024-09-14__11:34:45
commit: b46f70a4bf4240fbde26c126ce263e8ab3ecf4dc
options: gpl -O? cs:5 cl:2 make
```