### PR TITLE
Remove r2dec from docker, snap and flatpak installs

### DIFF
--- a/src/install/docker.md
+++ b/src/install/docker.md
@@ -21,7 +21,6 @@ The resulting build includes the following projects:
 * [radare2](https://github.com/radareorg/radare2)
 * [r2ghidra](https://github.com/radareorg/r2ghidra)
 * [r2frida](https://github.com/nowsecure/r2frida) (only in supported platforms)
-* [r2dec](https://github.com/wargio/r2dec-js)
 * [r2yara](https://github.com/radareorg/r2yara)
 * [r2ai](https://github.com/radareorg/r2ai) (only decai r2plugin)
 * [r2pipe](https://pypi.org/project/r2pipe/) (for Python)

--- a/src/install/flatpak.md
+++ b/src/install/flatpak.md
@@ -103,4 +103,4 @@ flatpak override --user --filesystem=/mnt/hdd:ro org.radare.iaito
 flatpak override --user --reset org.radare.iaito
 ```
 
-The Flatpak version of iaito comes bundled with several useful plugins: [r2dec](https://github.com/wargio/r2dec-js), [r2ghidra](https://github.com/radareorg/r2ghidra), [r2frida](https://github.com/nowsecure/r2frida), [r2yara](https://github.com/radareorg/r2yara), and [decai](https://github.com/radareorg/r2ai). These plugins enhance the functionality of radare2, providing additional capabilities for decompilation, integration with Ghidra, dynamic analysis with Frida, and YARA rule matching.
+The Flatpak version of iaito comes bundled with several useful plugins: [r2ghidra](https://github.com/radareorg/r2ghidra), [r2frida](https://github.com/nowsecure/r2frida), [r2yara](https://github.com/radareorg/r2yara), and [decai](https://github.com/radareorg/r2ai). These plugins enhance the functionality of radare2, providing additional capabilities for decompilation, integration with Ghidra, dynamic analysis with Frida, and YARA rule matching.


### PR DESCRIPTION
It has been removed r2dec-js from docker, snap and flatpak packages.

- https://github.com/flathub/org.radare.iaito/pull/103
- https://github.com/radareorg/radare2-snap/pull/7
